### PR TITLE
fix: do not fail publish on description override in OAS 3.0.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netcracker/qubership-apihub-api-diff": "dev",
-        "@netcracker/qubership-apihub-api-unifier": "1.0.4",
+        "@netcracker/qubership-apihub-api-diff": "bugfix-handle-rich-ref-separately",
+        "@netcracker/qubership-apihub-api-unifier": "bugfix-handle-rich-ref-separately",
         "@netcracker/qubership-apihub-graphapi": "1.0.8",
         "@netcracker/qubership-apihub-json-crawl": "1.0.4",
         "adm-zip": "0.5.10",
@@ -1749,11 +1749,11 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-api-diff": {
-      "version": "1.1.1-dev.20250413082112",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-diff/1.1.1-dev.20250413082112/59b77c11ee9933dfa5f71a1ecd9247e72a2a994b",
-      "integrity": "sha512-iD/PT5qaO/z1OBOH0jCRoU/5i2DXObGLg41gXOi7OJ4XjXLlfCgN9fJfFmf4UUdHxAzuduXtWzU5R4769hhQgQ==",
+      "version": "1.1.1-bugfix-handle-rich-ref-separately.20250425124400",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-diff/1.1.1-bugfix-handle-rich-ref-separately.20250425124400/856129f0499485f7190ff476f1fe4b71ad063e9b",
+      "integrity": "sha512-shL6ftAD2solsDAU9AH4IR73b/CUs9IrtNwafC270j0FUAyZ9rM/vRjmbjUcDthoHqtD6V5rBkfBffnB3/OQ0A==",
       "dependencies": {
-        "@netcracker/qubership-apihub-api-unifier": "1.0.4",
+        "@netcracker/qubership-apihub-api-unifier": "bugfix-handle-rich-ref-separately",
         "@netcracker/qubership-apihub-json-crawl": "1.0.4",
         "fast-equals": "4.0.3"
       }
@@ -1765,9 +1765,9 @@
       "license": "MIT"
     },
     "node_modules/@netcracker/qubership-apihub-api-unifier": {
-      "version": "1.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-unifier/1.0.4/b14d7eb994ca8c1ddcc42ed657ed7e434e2771d8",
-      "integrity": "sha512-v6ZonvhM+MqRjHvV8F/N9FnkhOZSq43GTl437eLW5k42kG7T5uq6J11oqVwTQKizvDmXSOXkuOTqrl6xkMKMdw==",
+      "version": "1.0.5-bugfix-handle-rich-ref-separately.20250425082053",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-unifier/1.0.5-bugfix-handle-rich-ref-separately.20250425082053/2e31a584338b06c351d2f987c5895a1245c242c2",
+      "integrity": "sha512-qWL1LsOp2JXOCnxf+GWFHYPJfva9WxmdjMVnGDYGYYuyeKHNaGn7N9MMiQD1+ce8u8K5ijHf6/t9R9HTYu3W0g==",
       "dependencies": {
         "@netcracker/qubership-apihub-json-crawl": "1.0.4",
         "fast-equals": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "release-finish": "release-finish"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-api-diff": "dev",
-    "@netcracker/qubership-apihub-api-unifier": "1.0.4",
+    "@netcracker/qubership-apihub-api-diff": "bugfix-handle-rich-ref-separately",
+    "@netcracker/qubership-apihub-api-unifier": "bugfix-handle-rich-ref-separately",
     "@netcracker/qubership-apihub-json-crawl": "1.0.4",
     "@netcracker/qubership-apihub-graphapi": "1.0.8",
     "adm-zip": "0.5.10",

--- a/src/apitypes/rest/rest.operations.ts
+++ b/src/apitypes/rest/rest.operations.ts
@@ -24,7 +24,7 @@ import type * as TYPE from './rest.types'
 import { HASH_FLAG, INLINE_REFS_FLAG, MESSAGE_SEVERITY, NORMALIZE_OPTIONS, ORIGINS_SYMBOL } from '../../consts'
 import { asyncFunction } from '../../utils/async'
 import { logLongBuild, syncDebugPerformance } from '../../utils/logs'
-import { normalize } from '@netcracker/qubership-apihub-api-unifier'
+import { normalize, RefErrorType } from '@netcracker/qubership-apihub-api-unifier'
 
 export const buildRestOperations: OperationsBuilder<OpenAPIV3.Document> = async (document, ctx, debugCtx) => {
   const documentWithoutComponents = removeComponents(document.data)
@@ -38,8 +38,8 @@ export const buildRestOperations: OperationsBuilder<OpenAPIV3.Document> = async 
         originsFlag: ORIGINS_SYMBOL,
         hashFlag: HASH_FLAG,
         source: document.data,
-        onRefResolveError: (_: string, __: PropertyKey[], ref: string) =>
-          bundlingErrorHandler([`The $ref "${ref}" references an invalid location in the document.`]),
+        onRefResolveError: (message: string, _path: PropertyKey[], _ref: string, errorType: RefErrorType) =>
+          bundlingErrorHandler([{ message, errorType }]),
       },
     ) as OpenAPIV3.Document
     const refsOnlyDocument = normalize(

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -29,13 +29,13 @@ import {
   PackageDocument,
   ResolvedDocument,
   VALIDATION_RULES_SEVERITY_LEVEL_ERROR,
-  VALIDATION_RULES_SEVERITY_LEVEL_WARNING,
   VersionDocument,
   YAML_EXPORT_GROUP_FORMAT,
 } from '../types'
 import { bundle, Resolver } from 'api-ref-bundler'
 import { FILE_FORMAT_JSON, FILE_FORMAT_YAML, MESSAGE_SEVERITY } from '../consts'
 import { isNotEmpty } from './arrays'
+import { RefErrorType, RefErrorTypes } from '@netcracker/qubership-apihub-api-unifier'
 
 export const EXPORT_FORMAT_TO_FILE_FORMAT = new Map<OperationsGroupExportFormat, FileFormat>([
   [YAML_EXPORT_GROUP_FORMAT, FILE_FORMAT_YAML],
@@ -121,42 +121,60 @@ export const getDocumentTitle = (fileId: string): string => {
   return fileId.substring(cutDot).split('/').pop()!.replace(/\.[^/.]+$/, '')
 }
 
-export const createBundlingErrorHandler = (ctx: BuilderContext, fileId: FileId) => (messages: string[]): void => {
-  switch (ctx.config.validationRulesSeverity?.brokenRefs) {
-    case VALIDATION_RULES_SEVERITY_LEVEL_ERROR:
-      throw new Error(messages[0])
-    case VALIDATION_RULES_SEVERITY_LEVEL_WARNING:
-    default:
-      for (const message of messages) {
-        ctx.notifications.push({
-          severity: MESSAGE_SEVERITY.Error,
-          message: message,
-          fileId: fileId,
-        })
-      }
+export interface BundlingError {
+  message: string
+  errorType: RefErrorType
+}
+
+export const createBundlingErrorHandler = (ctx: BuilderContext, fileId: FileId) => (errors: BundlingError[]): void => {
+  // Always push all errors to notifications
+  for (const error of errors) {
+    ctx.notifications.push({
+      severity: MESSAGE_SEVERITY.Error,
+      message: error.message,
+      fileId: fileId,
+    })
+  }
+
+  // Only throw if severity is ERROR and there's at least one critical error
+  if (ctx.config.validationRulesSeverity?.brokenRefs === VALIDATION_RULES_SEVERITY_LEVEL_ERROR) {
+    const criticalError = errors.find(error => 
+      error.errorType === RefErrorTypes.REF_NOT_FOUND || 
+      error.errorType === RefErrorTypes.REF_NOT_VALID_FORMAT,
+    )
+    
+    if (criticalError) {
+      throw new Error(criticalError.message)
+    }
   }
 }
 
 export const getBundledFileDataWithDependencies = async (
   fileId: FileId,
   parsedFileResolver: _ParsedFileResolver,
-  onError: (messages: string[]) => void,
+  onError: (errors: BundlingError[]) => void,
 ): Promise<{ data: any; dependencies: string[] }> => {
   const dependencies: string[] = []
-  const errorMessages: string[] = []
+  const errors: BundlingError[] = []
 
   const resolver: Resolver = async (filepath: string) => {
     const data = await parsedFileResolver(filepath)
 
     if (data === null) {
       // can't throw the error here because it will be suppressed: https://github.com/udamir/api-ref-bundler/blob/0.4.0/src/resolver.ts#L33
-      errorMessages.push(`Unable to resolve the file "${filepath}" because it does not exist.`)
+      errors.push({
+        message: `Unable to resolve the file "${filepath}" because it does not exist.`,
+        errorType: RefErrorTypes.REF_NOT_FOUND,
+      })
       return {}
     }
 
     if (data.kind !== FILE_KIND.TEXT) {
       // can't throw the error here because it will be suppressed: https://github.com/udamir/api-ref-bundler/blob/0.4.0/src/resolver.ts#L33
-      errorMessages.push(`Unable to resolve the file "${filepath}" because it is not a valid text file.`)
+      errors.push({
+        message: `Unable to resolve the file "${filepath}" because it is not a valid text file.`,
+        errorType: RefErrorTypes.REF_NOT_VALID_FORMAT,
+      })
       return {}
     }
 
@@ -169,8 +187,8 @@ export const getBundledFileDataWithDependencies = async (
 
   const bundledFileData = await bundle(fileId, resolver)
 
-  if (isNotEmpty(errorMessages)) {
-    onError(errorMessages)
+  if (isNotEmpty(errors)) {
+    onError(errors)
   }
 
   return { data: bundledFileData, dependencies: dependencies }

--- a/test/projects/reference-bundling/description-override/config.json
+++ b/test/projects/reference-bundling/description-override/config.json
@@ -1,0 +1,13 @@
+{
+  "packageId": "reference-bundling/description-override",
+  "apiType": "rest",
+  "version": "v1",
+  "files": [
+    {
+      "fileId": "openapi.yaml",
+      "publish": true,
+      "labels": [],
+      "commitId": "6c778b1f44200bd19944a6a8eac10a4e5a21a1xd"
+    }
+  ]
+}

--- a/test/projects/reference-bundling/description-override/openapi.yaml
+++ b/test/projects/reference-bundling/description-override/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: test
+  version: 0.1.0
+paths:
+  /path1:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Test'
+                description: Description override
+components:
+  schemas:
+    Test:
+      type: object

--- a/test/reference-bundling.test.ts
+++ b/test/reference-bundling.test.ts
@@ -22,7 +22,7 @@ describe('Reference bundling test', () => {
     const result = await pkg.publish(pkg.packageId)
 
     expect(result).toEqual(notificationsMatcher([
-      errorNotificationMatcher('references an invalid location'),
+      errorNotificationMatcher('can\'t be resolved'),
       errorNotificationMatcher('does not exist'),
     ]))
     expect(result.operations.size).toBe(1)
@@ -52,7 +52,7 @@ describe('Reference bundling test', () => {
     const result = await pkg.publish(pkg.packageId)
 
     expect(result).toEqual(notificationsMatcher([
-      errorNotificationMatcher('references an invalid location'),
+      errorNotificationMatcher('can\'t be resolved'),
       errorNotificationMatcher('does not exist'),
     ]))
     expect(result.operations.size).toBe(1)
@@ -64,14 +64,14 @@ describe('Reference bundling test', () => {
 
     await expect(
       pkg.publish(pkg.packageId, { validationRulesSeverity: { brokenRefs: VALIDATION_RULES_SEVERITY_LEVEL_ERROR } }),
-    ).rejects.toThrow(/references an invalid location/)
+    ).rejects.toThrow(/can't be resolved/)
   })
 
   test('should collect missing internal reference notification if severity level is not configured', async () => {
     const pkg = LocalRegistry.openPackage('reference-bundling/case5')
     const result = await pkg.publish(pkg.packageId)
 
-    expect(result).toEqual(notificationsMatcher([errorNotificationMatcher('references an invalid location')]))
+    expect(result).toEqual(notificationsMatcher([errorNotificationMatcher('can\'t be resolved')]))
     expect(result.operations.size).toBe(1)
   })
 
@@ -80,5 +80,19 @@ describe('Reference bundling test', () => {
     await expect(
       pkg.publish(pkg.packageId, { validationRulesSeverity: { brokenRefs: VALIDATION_RULES_SEVERITY_LEVEL_ERROR } }),
     ).rejects.toThrow(/not a valid text file/)
+  })
+
+  test('should not throw error on publishing specification with incorrect description override', async () => {
+    const pkg = LocalRegistry.openPackage('reference-bundling/description-override')
+    const result = await pkg.publish(pkg.packageId, {
+      validationRulesSeverity: {
+        brokenRefs: VALIDATION_RULES_SEVERITY_LEVEL_ERROR,
+      },
+    })
+
+    expect(result).toEqual(notificationsMatcher([
+      errorNotificationMatcher('can\'t have siblings in this specification version'),      
+    ]))
+    expect(result.operations.size).toBe(1)    
   })
 })


### PR DESCRIPTION
* split 3 types of possible reference errors
* only fail publication for REF_NOT_FOUND or REF_NOT_VALID_FORMAT
* add corresponding test