### PR TITLE
refactor: invertMap function typing improvement

### DIFF
--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -270,13 +270,13 @@ export async function prepareChangelogDashboard(
   })
 }
 
-const invertMap = (map: Map<unknown, unknown>): Map<unknown, unknown> => {
+const invertMap = <K, V>(map: Map<K, V>): Map<V, K> => {
   return new Map(
-    [...map].map(([key, value]) => [value, key]),
+    [...map].map(([key, value]: [K, V]) => [value, key]),
   )
 }
 
-const DESERIALIZE_SYMBOL_STRING_MAPPING = invertMap(SERIALIZE_SYMBOL_STRING_MAPPING) as Map<string, symbol>
+const DESERIALIZE_SYMBOL_STRING_MAPPING = invertMap(SERIALIZE_SYMBOL_STRING_MAPPING)
 
 export function deserializeDocument(serializedDocument: string): ApiDocument {
   return deserialize(serializedDocument, DESERIALIZE_SYMBOL_STRING_MAPPING) as ApiDocument


### PR DESCRIPTION
**Add generic typing to** `invertMap`
Updated invertMap to use generics instead of unknown types.

**What changed:**
Replaced `Map<unknown, unknown>` with generic `Map<K, V>`
Added proper return type `Map<V, K>`

**Why:**
- preserves key/value type information instead of erasing it with unknown
- improves type safety and autocomplete
- makes the function reusable and easier to reason about

**Behavior remains unchanged** — this is a type-level improvement only.