### PR TITLE
fix: ApiCompatibilityScopeFunction logic- return undefined if there a…

### DIFF
--- a/src/components/compare/async.bwc.validation.ts
+++ b/src/components/compare/async.bwc.validation.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { APIHUB_API_COMPATIBILITY_KIND_BWC, APIHUB_API_COMPATIBILITY_KIND_NO_BWC } from '../../consts'
-import { isObject } from '../../utils'
+import { APIHUB_API_COMPATIBILITY_KIND_BWC, APIHUB_API_COMPATIBILITY_KIND_NO_BWC, ApihubApiCompatibilityKind } from '../../consts'
 import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
 import {
   API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE,
@@ -29,6 +28,13 @@ import { ApiCompatibilityScopeFunctionFactory } from './bwc.validation.types'
 const ROOT_PATH_LENGTH = 0
 const ASYNC_OPERATION_PATH_LENGTH = 2 // operations/<operationId>
 const ASYNC_CHANNEL_PATH_LENGTH = 2   // channels/<channelId>
+
+const hasExplicitKind = (
+  beforeKind: ApihubApiCompatibilityKind | undefined,
+  afterKind: ApihubApiCompatibilityKind | undefined,
+  explicitKind: ApihubApiCompatibilityKind): boolean => {
+  return beforeKind === explicitKind || afterKind === explicitKind
+}
 
 /**
  * Creates an ApiCompatibilityScopeFunction for AsyncAPI documents.
@@ -49,7 +55,7 @@ export const createAsyncApiCompatibilityScopeFunction: ApiCompatibilityScopeFunc
   prevDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
   currDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
 ) => {
-  const defaultApiCompatibilityKind = (prevDocumentApiKind === APIHUB_API_COMPATIBILITY_KIND_NO_BWC || currDocumentApiKind === APIHUB_API_COMPATIBILITY_KIND_NO_BWC)
+  const defaultApiCompatibilityKind = hasExplicitKind(prevDocumentApiKind, currDocumentApiKind, APIHUB_API_COMPATIBILITY_KIND_NO_BWC)
     ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
     : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
 
@@ -65,12 +71,6 @@ export const createAsyncApiCompatibilityScopeFunction: ApiCompatibilityScopeFunc
     }
 
     const firstSegment = path?.[0]
-    const beforeExists = isObject(beforeJso)
-    const afterExists = isObject(afterJso)
-
-    if (!beforeExists && !afterExists) {
-      return undefined
-    }
 
     // operations/<operationId>: resolve api-kind from operation x-api-kind with channel fallback
     if (firstSegment === 'operations' && pathLength === ASYNC_OPERATION_PATH_LENGTH) {
@@ -79,14 +79,27 @@ export const createAsyncApiCompatibilityScopeFunction: ApiCompatibilityScopeFunc
       const afterChannelKind = getApiKindProperty((afterJso as AsyncAPIV3.OperationObject | undefined)?.channel)
 
       // Operation's own x-api-kind takes priority, falls back to channel's x-api-kind
-      const beforeOperationKind = getApiKindProperty(beforeJso, beforeChannelKind)
-      const afterOperationKind = getApiKindProperty(afterJso, afterChannelKind)
+      const beforeOperationKind = getApiKindProperty(beforeJso)
+      const afterOperationKind = getApiKindProperty(afterJso)
 
-      if (beforeOperationKind === APIHUB_API_COMPATIBILITY_KIND_NO_BWC || afterOperationKind === APIHUB_API_COMPATIBILITY_KIND_NO_BWC) {
+      // if before or after operation has explicit kind, return the explicit kind (no-bwc takes priority over bwc)
+      if (hasExplicitKind(beforeOperationKind, afterOperationKind, APIHUB_API_COMPATIBILITY_KIND_NO_BWC)) {
         return API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
       }
+      if (hasExplicitKind(beforeOperationKind, afterOperationKind, APIHUB_API_COMPATIBILITY_KIND_BWC)) {
+        return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+      }
 
-      return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+      // otherwise, if before or after channel has explicit kind, return the explicit kind (no-bwc takes priority over bwc)
+      if (hasExplicitKind(beforeChannelKind, afterChannelKind, APIHUB_API_COMPATIBILITY_KIND_NO_BWC)) {
+        return API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
+      }
+      if (hasExplicitKind(beforeChannelKind, afterChannelKind, APIHUB_API_COMPATIBILITY_KIND_BWC)) {
+        return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+      }
+
+      // neither operation nor channel has explicit kind, return undefined
+      return undefined
     }
 
     // channels/<channelId>: use channel's own x-api-kind
@@ -94,11 +107,16 @@ export const createAsyncApiCompatibilityScopeFunction: ApiCompatibilityScopeFunc
       const beforeChannelKind = getApiKindProperty(beforeJso)
       const afterChannelKind = getApiKindProperty(afterJso)
 
-      if (beforeChannelKind === APIHUB_API_COMPATIBILITY_KIND_NO_BWC || afterChannelKind === APIHUB_API_COMPATIBILITY_KIND_NO_BWC) {
+      // if before or after channel has explicit kind, return the explicit kind (no-bwc takes priority over bwc)
+      if (hasExplicitKind(beforeChannelKind, afterChannelKind, APIHUB_API_COMPATIBILITY_KIND_NO_BWC)) {
         return API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
       }
+      if (hasExplicitKind(beforeChannelKind, afterChannelKind, APIHUB_API_COMPATIBILITY_KIND_BWC)) {
+        return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+      }
 
-      return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+      // channel does not have explicit kind, return undefined
+      return undefined
     }
 
     return undefined

--- a/src/components/compare/async.bwc.validation.ts
+++ b/src/components/compare/async.bwc.validation.ts
@@ -78,7 +78,6 @@ export const createAsyncApiCompatibilityScopeFunction: ApiCompatibilityScopeFunc
       const beforeChannelKind = getApiKindProperty((beforeJso as AsyncAPIV3.OperationObject | undefined)?.channel)
       const afterChannelKind = getApiKindProperty((afterJso as AsyncAPIV3.OperationObject | undefined)?.channel)
 
-      // Operation's own x-api-kind takes priority, falls back to channel's x-api-kind
       const beforeOperationKind = getApiKindProperty(beforeJso)
       const afterOperationKind = getApiKindProperty(afterJso)
 

--- a/test/asyncapi-apikind.test.ts
+++ b/test/asyncapi-apikind.test.ts
@@ -67,86 +67,78 @@ describe('AsyncAPI apiKind calculation', () => {
       })
 
       describe('Channels scope', () => {
-        it.each([
-          // default        | before           | after            | expected
-          // undefined JSO = channel added/removed
-          ['bwc', channel(), channel(), BWC],
-          ['bwc', channel(), bwcChannel(), BWC],
-          ['bwc', channel(), noBwcChannel(), NOT_BWC],
-          ['bwc', bwcChannel(), channel(), BWC],
-          ['bwc', bwcChannel(), bwcChannel(), BWC],
-          ['bwc', bwcChannel(), noBwcChannel(), NOT_BWC],
-          ['bwc', noBwcChannel(), channel(), NOT_BWC],
-          ['bwc', noBwcChannel(), bwcChannel(), NOT_BWC],
-          ['bwc', noBwcChannel(), noBwcChannel(), NOT_BWC],
-          ['bwc', undefined, channel(), BWC],
-          ['bwc', undefined, noBwcChannel(), NOT_BWC],
-          ['bwc', channel(), undefined, BWC],
-          ['bwc', noBwcChannel(), undefined, NOT_BWC],
-          ['bwc', undefined, undefined, undefined],
-          ['no-bwc', channel(), channel(), BWC],
-          ['no-bwc', channel(), bwcChannel(), BWC],
-          ['no-bwc', channel(), noBwcChannel(), NOT_BWC],
-          ['no-bwc', bwcChannel(), channel(), BWC],
-          ['no-bwc', bwcChannel(), bwcChannel(), BWC],
-          ['no-bwc', bwcChannel(), noBwcChannel(), NOT_BWC],
-          ['no-bwc', noBwcChannel(), channel(), NOT_BWC],
-          ['no-bwc', noBwcChannel(), bwcChannel(), NOT_BWC],
-          ['no-bwc', noBwcChannel(), noBwcChannel(), NOT_BWC],
-          ['no-bwc', undefined, channel(), BWC],
-          ['no-bwc', undefined, noBwcChannel(), NOT_BWC],
-          ['no-bwc', channel(), undefined, BWC],
-          ['no-bwc', noBwcChannel(), undefined, NOT_BWC],
-          ['no-bwc', undefined, undefined, undefined],
-        ] as const)('documentApiKind: %s, before: %s, after: %s', (
+        // before           | after            | expected
+        // undefined JSO = channel added/removed
+        const CHANNELS_TEST_DATA_SINGLE_SCOPE = [
+          [channel(), channel(), undefined],
+          [channel(), bwcChannel(), BWC],
+          [channel(), noBwcChannel(), NOT_BWC],
+          [channel(), undefined, undefined],
+          [bwcChannel(), channel(), BWC],
+          [bwcChannel(), bwcChannel(), BWC],
+          [bwcChannel(), noBwcChannel(), NOT_BWC],
+          [bwcChannel(), undefined, BWC],
+          [noBwcChannel(), channel(), NOT_BWC],
+          [noBwcChannel(), bwcChannel(), NOT_BWC],
+          [noBwcChannel(), noBwcChannel(), NOT_BWC],
+          [noBwcChannel(), undefined, NOT_BWC],
+          [undefined, channel(), undefined],
+          [undefined, bwcChannel(), BWC],
+          [undefined, noBwcChannel(), NOT_BWC],
+          [undefined, undefined, undefined],
+        ]
+        // Expected is the same for both documentApiKinds
+        const CHANNELS_TEST_DATA = [
+          ...['bwc', 'no-bwc'].flatMap(
+            documentApiKind =>
+              CHANNELS_TEST_DATA_SINGLE_SCOPE.map(testData => [documentApiKind, ...testData]),
+          ),
+        ]
+        it.each(CHANNELS_TEST_DATA)('documentApiKind: %s, before: %s, after: %s', (
           documentApiKind,
           beforeJso,
           afterJso,
           expected,
         ) => {
-          const scopeFunction = createAsyncApiCompatibilityScopeFunction(documentApiKind)
+          const scopeFunction = createAsyncApiCompatibilityScopeFunction(documentApiKind as ApihubApiCompatibilityKind, documentApiKind as ApihubApiCompatibilityKind)
           expect(scopeFunction(['channels', 'ch1'], beforeJso, afterJso)).toBe(expected)
         })
       })
 
       describe('Operations scope', () => {
-        it.each([
-          // default        | before              | after               | expected
-          ['bwc', operation(), operation(), BWC],
-          ['bwc', operation(), bwcOperation(), BWC],
-          ['bwc', operation(), noBwcOperation(), NOT_BWC],
-          ['bwc', bwcOperation(), operation(), BWC],
-          ['bwc', bwcOperation(), bwcOperation(), BWC],
-          ['bwc', bwcOperation(), noBwcOperation(), NOT_BWC],
-          ['bwc', noBwcOperation(), operation(), NOT_BWC],
-          ['bwc', noBwcOperation(), bwcOperation(), NOT_BWC],
-          ['bwc', noBwcOperation(), noBwcOperation(), NOT_BWC],
-          ['bwc', undefined, operation(), BWC],
-          ['bwc', undefined, noBwcOperation(), NOT_BWC],
-          ['bwc', operation(), undefined, BWC],
-          ['bwc', noBwcOperation(), undefined, NOT_BWC],
-          ['bwc', undefined, undefined, undefined],
-          ['no-bwc', operation(), operation(), BWC],
-          ['no-bwc', operation(), bwcOperation(), BWC],
-          ['no-bwc', operation(), noBwcOperation(), NOT_BWC],
-          ['no-bwc', bwcOperation(), operation(), BWC],
-          ['no-bwc', bwcOperation(), bwcOperation(), BWC],
-          ['no-bwc', bwcOperation(), noBwcOperation(), NOT_BWC],
-          ['no-bwc', noBwcOperation(), operation(), NOT_BWC],
-          ['no-bwc', noBwcOperation(), bwcOperation(), NOT_BWC],
-          ['no-bwc', noBwcOperation(), noBwcOperation(), NOT_BWC],
-          ['no-bwc', undefined, operation(), BWC],
-          ['no-bwc', undefined, noBwcOperation(), NOT_BWC],
-          ['no-bwc', operation(), undefined, BWC],
-          ['no-bwc', noBwcOperation(), undefined, NOT_BWC],
-          ['no-bwc', undefined, undefined, undefined],
-        ] as const)('documentApiKind: %s, before: %s, after: %s', (
+        const OPERATIONS_TEST_DATA_SINGLE_SCOPE = [
+          // before           | after            | expected
+          [operation(), operation(), undefined],
+          [operation(), bwcOperation(), BWC],
+          [operation(), noBwcOperation(), NOT_BWC],
+          [operation(), undefined, undefined],
+          [bwcOperation(), operation(), BWC],
+          [bwcOperation(), bwcOperation(), BWC],
+          [bwcOperation(), noBwcOperation(), NOT_BWC],
+          [bwcOperation(), undefined, BWC],
+          [noBwcOperation(), operation(), NOT_BWC],
+          [noBwcOperation(), bwcOperation(), NOT_BWC],
+          [noBwcOperation(), noBwcOperation(), NOT_BWC],
+          [noBwcOperation(), undefined, NOT_BWC],
+          [undefined, operation(), undefined],
+          [undefined, bwcOperation(), BWC],
+          [undefined, noBwcOperation(), NOT_BWC],
+          [undefined, undefined, undefined],
+        ]
+        // Expected is the same for both documentApiKinds
+        const OPERATIONS_TEST_DATA = [
+          ...['bwc', 'no-bwc'].flatMap(
+            documentApiKind =>
+              OPERATIONS_TEST_DATA_SINGLE_SCOPE.map(testData => [documentApiKind, ...testData]),
+          ),
+        ]
+        it.each(OPERATIONS_TEST_DATA)('documentApiKind: %s, before: %s, after: %s', (
           documentApiKind,
           beforeJso,
           afterJso,
           expected,
         ) => {
-          const scopeFunction = createAsyncApiCompatibilityScopeFunction(documentApiKind)
+          const scopeFunction = createAsyncApiCompatibilityScopeFunction(documentApiKind as ApihubApiCompatibilityKind, documentApiKind as ApihubApiCompatibilityKind)
           expect(scopeFunction(['operations', 'op1'], beforeJso, afterJso)).toBe(expected)
         })
 


### PR DESCRIPTION
add missing test data cases for channels scope and operations
refactor test data to avoid duplication and emphasize that ER is independent of documentApiKind