### PR TITLE
fix: filter channel messages per operation in createOperationSpec for AsyncAPI

### DIFF
--- a/src/apitypes/async/async.operation.ts
+++ b/src/apitypes/async/async.operation.ts
@@ -50,6 +50,7 @@ import {
   createBaseAsyncApiSpec,
   enrichAsyncApiWithInlineRefs,
   extractProtocol,
+  filterChannelMessages,
   getAsyncMessageId,
   isMessageObject,
   resolveAsyncApiOperationIdsFromRefs,
@@ -275,7 +276,11 @@ export const createOperationSpec = (
       )
 
       if (requestedIdsSet.has(calculatedId)) {
-        selectedOperations[asyncOperationId] = operationObject
+        selectedOperations[asyncOperationId] = {
+          ...operationObject,
+          messages: [message],
+          channel: filterChannelMessages(channel as AsyncAPIV3.ChannelObject, messageId),
+        }
         break
       }
     }

--- a/src/apitypes/async/async.operation.ts
+++ b/src/apitypes/async/async.operation.ts
@@ -292,7 +292,19 @@ export const createOperationSpec = (
     }
   }
 
-  return createBaseAsyncApiSpec(normalizedDocument, selectedOperations)
+  // Build root channels record from filtered channels, keyed by their original name
+  let channels: Record<string, AsyncAPIV3.ChannelObject> | undefined
+  if (filteredChannels.size > 0 && normalizedDocument.channels) {
+    channels = {}
+    for (const [channelName, channelObj] of Object.entries(normalizedDocument.channels)) {
+      const filteredChannel = filteredChannels.get(channelObj as AsyncAPIV3.ChannelObject)
+      if (filteredChannel) {
+        channels[channelName] = filteredChannel
+      }
+    }
+  }
+
+  return createBaseAsyncApiSpec(normalizedDocument, selectedOperations, channels)
 }
 
 /**

--- a/src/apitypes/async/async.operation.ts
+++ b/src/apitypes/async/async.operation.ts
@@ -44,13 +44,14 @@ import {
 } from '@netcracker/qubership-apihub-api-unifier'
 import { calculateHash, ObjectHashCache } from '../../utils/hashes'
 import {
+  addMessageToOperation,
   buildAsyncApiSpecFromDocument,
   calculateAsyncApiKind,
   checkHasAsyncApiOperations,
   createBaseAsyncApiSpec,
+  createOperationWithSingleMessage,
   enrichAsyncApiWithInlineRefs,
   extractProtocol,
-  filterChannelMessages,
   getAsyncMessageId,
   isMessageObject,
   resolveAsyncApiOperationIdsFromRefs,
@@ -258,6 +259,7 @@ export const createOperationSpec = (
     if (!action || !channel) {
       continue
     }
+    const channelObj = channel as AsyncAPIV3.ChannelObject
 
     for (const message of messages) {
       if (!isMessageObject(message)) {
@@ -276,12 +278,12 @@ export const createOperationSpec = (
       )
 
       if (requestedIdsSet.has(calculatedId)) {
-        selectedOperations[asyncOperationId] = {
-          ...operationObject,
-          messages: [message],
-          channel: filterChannelMessages(channel as AsyncAPIV3.ChannelObject, messageId),
+        const selectedOperation = selectedOperations[asyncOperationId]
+        if (selectedOperation) {
+          addMessageToOperation(selectedOperation, channelObj, message, messageId)
+        } else {
+          selectedOperations[asyncOperationId] = createOperationWithSingleMessage(operationObject, channelObj, message, messageId)
         }
-        break
       }
     }
   }

--- a/src/apitypes/async/async.operation.ts
+++ b/src/apitypes/async/async.operation.ts
@@ -44,15 +44,14 @@ import {
 } from '@netcracker/qubership-apihub-api-unifier'
 import { calculateHash, ObjectHashCache } from '../../utils/hashes'
 import {
-  addMessageToOperation,
   buildAsyncApiSpecFromDocument,
   calculateAsyncApiKind,
   checkHasAsyncApiOperations,
   createBaseAsyncApiSpec,
-  createOperationWithSingleMessage,
   enrichAsyncApiWithInlineRefs,
   extractProtocol,
   getAsyncMessageId,
+  getOrCreateFilteredChannel,
   isMessageObject,
   resolveAsyncApiOperationIdsFromRefs,
 } from './async.utils'
@@ -245,6 +244,9 @@ export const createOperationSpec = (
   const requestedIdsSet = new Set(operationIds)
 
   const selectedOperations: Record<string, AsyncAPIV3.OperationObject> = {}
+  // Maps source channel → filtered copy with only requested messages.
+  const filteredChannels = new Map<AsyncAPIV3.ChannelObject, AsyncAPIV3.ChannelObject>()
+
   for (const [asyncOperationId, operationData] of Object.entries(operations)) {
     if (!isObject(operationData)) {
       continue
@@ -279,10 +281,12 @@ export const createOperationSpec = (
 
       if (requestedIdsSet.has(calculatedId)) {
         const selectedOperation = selectedOperations[asyncOperationId]
+        // Always update the shared filtered channel — both branches need the message registered
+        const filteredChannel = getOrCreateFilteredChannel(filteredChannels, channelObj, messageId)
         if (selectedOperation) {
-          addMessageToOperation(selectedOperation, channelObj, message, messageId)
+          (selectedOperation.messages as AsyncAPIV3.MessageObject[]).push(message)
         } else {
-          selectedOperations[asyncOperationId] = createOperationWithSingleMessage(operationObject, channelObj, message, messageId)
+          selectedOperations[asyncOperationId] = { ...operationObject, messages: [message], channel: filteredChannel }
         }
       }
     }

--- a/src/apitypes/async/async.utils.ts
+++ b/src/apitypes/async/async.utils.ts
@@ -44,7 +44,7 @@ import {
   INLINE_REFS_FLAG,
 } from '../../consts'
 import { WithAggregatedDiffs, WithDiffMetaRecord } from '../../types'
-import { Diff, DiffAction, DIFF_META_KEY, DIFFS_AGGREGATED_META_KEY } from '@netcracker/qubership-apihub-api-diff'
+import { Diff, DIFF_META_KEY, DIFFS_AGGREGATED_META_KEY } from '@netcracker/qubership-apihub-api-diff'
 
 // Re-export shared utilities
 export { dump, getCustomTags, resolveApiAudience } from '../../utils/apihubSpecificationExtensions'
@@ -131,15 +131,25 @@ export const getAsyncChannelId = (channel: AsyncAPIV3.ChannelObject): string => 
   return getAsyncObjectId(channel)
 }
 
-export const filterChannelMessages = (
+export const createOperationWithSingleMessage = (
+  operationObject: AsyncAPIV3.OperationObject,
   channel: AsyncAPIV3.ChannelObject,
+  message: AsyncAPIV3.MessageObject,
   messageId: string,
-): AsyncAPIV3.ChannelObject => {
-  const channelMessages = (channel as AsyncAPIV3.ChannelObject).messages
-  if (!isObject(channelMessages)) {
-    return channel
-  }
-  return { ...channel, messages: { [messageId]: (channelMessages as AsyncAPIV3.MessagesObject)[messageId] } }
+): AsyncAPIV3.OperationObject => {
+  const filteredChannel = { ...channel, messages: { [messageId]: channel.messages![messageId] } }
+  return { ...operationObject, messages: [message], channel: filteredChannel }
+}
+
+export const addMessageToOperation = (
+  operation: AsyncAPIV3.OperationObject,
+  sourceChannel: AsyncAPIV3.ChannelObject,
+  message: AsyncAPIV3.MessageObject,
+  messageId: string,
+): void => {
+  (operation.messages as AsyncAPIV3.MessageObject[]).push(message)
+  const operationChannel = operation.channel as AsyncAPIV3.ChannelObject
+  operationChannel.messages![messageId] = sourceChannel.messages![messageId]
 }
 
 export const checkHasAsyncApiOperations = (

--- a/src/apitypes/async/async.utils.ts
+++ b/src/apitypes/async/async.utils.ts
@@ -163,14 +163,26 @@ export const checkHasAsyncApiOperations = (
   return operations as Record<string, AsyncAPIV3.OperationObject>
 }
 
+/**
+ * Creates the base AsyncAPI operation spec containing only the essential
+ * contract elements: version, info, operations, and optionally channels.
+ *
+ * Channels are a core part of the AsyncAPI contract — they define the
+ * communication addresses and the messages available on each address.
+ * When provided, channels are included at the root level so that the
+ * resulting spec remains a valid, self-contained AsyncAPI document fragment
+ * that accurately represents the operation's messaging contract.
+ */
 export const createBaseAsyncApiSpec = (
   document: AsyncAPIV3.AsyncAPIObject,
   operations: Record<string, AsyncAPIV3.OperationObject>,
+  channels?: AsyncAPIV3.ChannelsObject,
 ): TYPE.AsyncOperationData => ({
   asyncapi: document.asyncapi || '3.0.0',
   info: document.info,
   ...takeIfDefined({ id: document.id }),
   ...takeIfDefined({ defaultContentType: document.defaultContentType }),
+  ...takeIfDefined({ channels }),
   operations,
 })
 

--- a/src/apitypes/async/async.utils.ts
+++ b/src/apitypes/async/async.utils.ts
@@ -131,6 +131,17 @@ export const getAsyncChannelId = (channel: AsyncAPIV3.ChannelObject): string => 
   return getAsyncObjectId(channel)
 }
 
+export const filterChannelMessages = (
+  channel: AsyncAPIV3.ChannelObject,
+  messageId: string,
+): AsyncAPIV3.ChannelObject => {
+  const channelMessages = (channel as AsyncAPIV3.ChannelObject).messages
+  if (!isObject(channelMessages)) {
+    return channel
+  }
+  return { ...channel, messages: { [messageId]: (channelMessages as AsyncAPIV3.MessagesObject)[messageId] } }
+}
+
 export const checkHasAsyncApiOperations = (
   document: AsyncAPIV3.AsyncAPIObject,
 ): Record<string, AsyncAPIV3.OperationObject> => {

--- a/src/apitypes/async/async.utils.ts
+++ b/src/apitypes/async/async.utils.ts
@@ -166,12 +166,6 @@ export const checkHasAsyncApiOperations = (
 /**
  * Creates the base AsyncAPI operation spec containing only the essential
  * contract elements: version, info, operations, and optionally channels.
- *
- * Channels are a core part of the AsyncAPI contract — they define the
- * communication addresses and the messages available on each address.
- * When provided, channels are included at the root level so that the
- * resulting spec remains a valid, self-contained AsyncAPI document fragment
- * that accurately represents the operation's messaging contract.
  */
 export const createBaseAsyncApiSpec = (
   document: AsyncAPIV3.AsyncAPIObject,

--- a/src/apitypes/async/async.utils.ts
+++ b/src/apitypes/async/async.utils.ts
@@ -165,7 +165,7 @@ export const checkHasAsyncApiOperations = (
 
 /**
  * Creates the base AsyncAPI operation spec containing only the essential
- * contract elements: version, info, operations, and optionally channels.
+ * contract elements: version, info, operations, and channels.
  */
 export const createBaseAsyncApiSpec = (
   document: AsyncAPIV3.AsyncAPIObject,

--- a/src/apitypes/async/async.utils.ts
+++ b/src/apitypes/async/async.utils.ts
@@ -131,25 +131,24 @@ export const getAsyncChannelId = (channel: AsyncAPIV3.ChannelObject): string => 
   return getAsyncObjectId(channel)
 }
 
-export const createOperationWithSingleMessage = (
-  operationObject: AsyncAPIV3.OperationObject,
-  channel: AsyncAPIV3.ChannelObject,
-  message: AsyncAPIV3.MessageObject,
-  messageId: string,
-): AsyncAPIV3.OperationObject => {
-  const filteredChannel = { ...channel, messages: { [messageId]: channel.messages![messageId] } }
-  return { ...operationObject, messages: [message], channel: filteredChannel }
-}
-
-export const addMessageToOperation = (
-  operation: AsyncAPIV3.OperationObject,
+/**
+ * Returns a filtered copy of the channel, creating one if it doesn't exist yet.
+ * All operations that share the same source channel will get the same filtered instance,
+ * accumulating only the messages that are actually requested.
+ */
+export const getOrCreateFilteredChannel = (
+  channelCache: Map<AsyncAPIV3.ChannelObject, AsyncAPIV3.ChannelObject>,
   sourceChannel: AsyncAPIV3.ChannelObject,
-  message: AsyncAPIV3.MessageObject,
   messageId: string,
-): void => {
-  (operation.messages as AsyncAPIV3.MessageObject[]).push(message)
-  const operationChannel = operation.channel as AsyncAPIV3.ChannelObject
-  operationChannel.messages![messageId] = sourceChannel.messages![messageId]
+): AsyncAPIV3.ChannelObject => {
+  let filteredChannel = channelCache.get(sourceChannel)
+  if (!filteredChannel) {
+    filteredChannel = { ...sourceChannel, messages: { [messageId]: sourceChannel.messages![messageId] } }
+    channelCache.set(sourceChannel, filteredChannel)
+  } else {
+    filteredChannel.messages![messageId] = sourceChannel.messages![messageId]
+  }
+  return filteredChannel
 }
 
 export const checkHasAsyncApiOperations = (

--- a/test/asyncapi-deprecated.test.ts
+++ b/test/asyncapi-deprecated.test.ts
@@ -1,4 +1,4 @@
- /**
+/**
  * Copyright 2024-2025 NetCracker Technology Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ describe('AsyncAPI 3.0 Deprecated tests', () => {
 
     test('should deprecated message has OperationDeprecated symbol with true', async () => {
       const [deprecatedItem] = deprecatedItems
-      const operationDeprecatedSymbol  = (deprecatedItem as unknown as Record<symbol, boolean>)[isOperationDeprecated]
+      const operationDeprecatedSymbol = (deprecatedItem as unknown as Record<symbol, boolean>)[isOperationDeprecated]
       expect(operationDeprecatedSymbol).toBeTruthy()
     })
   })

--- a/test/asyncapi-deprecated.test.ts
+++ b/test/asyncapi-deprecated.test.ts
@@ -1,4 +1,4 @@
-/**
+ /**
  * Copyright 2024-2025 NetCracker Technology Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,6 +77,26 @@ describe('AsyncAPI 3.0 Deprecated tests', () => {
 
     const [operation] = operations
     expect(operation.deprecated).toBe(true)
+  })
+
+  describe('Shared channel with different deprecation per message', () => {
+    test('should only report deprecated items for the operation that uses the deprecated message', async () => {
+      const result = await buildPackageWithDefaultConfig('asyncapi/deprecated/shared-channel-different-deprecation')
+      const operations = Array.from(result.operations.entries())
+
+      // operation1 uses UserSignedUp (deprecated: false on email) — should have NO deprecated items
+      const operation1Entry = operations.find(([key]) => key.includes('operation1'))
+      expect(operation1Entry).toBeDefined()
+      const operation1DeprecatedItems = operation1Entry![1].deprecatedItems ?? []
+
+      // operation2 uses UserQuit (deprecated: true on email) — should have deprecated items
+      const operation2Entry = operations.find(([key]) => key.includes('operation2'))
+      expect(operation2Entry).toBeDefined()
+      const operation2DeprecatedItems = operation2Entry![1].deprecatedItems ?? []
+
+      expect(operation1DeprecatedItems.length).toBe(0)
+      expect(operation2DeprecatedItems.length).toBeGreaterThan(0)
+    })
   })
 
   test('should report deprecated schemas (flag "deprecated" in payload schema)', async () => {

--- a/test/asyncapi-deprecated.test.ts
+++ b/test/asyncapi-deprecated.test.ts
@@ -95,7 +95,7 @@ describe('AsyncAPI 3.0 Deprecated tests', () => {
       const operation2DeprecatedItems = operation2Entry![1].deprecatedItems ?? []
 
       expect(operation1DeprecatedItems.length).toBe(0)
-      expect(operation2DeprecatedItems.length).toBeGreaterThan(0)
+      expect(operation2DeprecatedItems.length).toBe(1)
     })
   })
 

--- a/test/asyncapi-operation.test.ts
+++ b/test/asyncapi-operation.test.ts
@@ -359,43 +359,57 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
     })
 
     describe('shared channel message filtering', () => {
-      const SHARED_OP_KEY_A = 'operationA'
-      const SHARED_OP_KEY_B = 'operationB'
-      const SHARED_MSG_ID_A = 'MessageA'
-      const SHARED_MSG_ID_B = 'MessageB'
+      const SHARED_ASYNC_OP = 'multiMessageOp'
+      const SHARED_MESSAGE_ID_A = 'MessageA'
+      const SHARED_MESSAGE_ID_B = 'MessageB'
+      const SHARED_MESSAGE_ID_C = 'MessageC'
 
-      let sharedChannelDoc: AsyncAPIV3.AsyncAPIObject
       let sharedChannelNormalized: AsyncAPIV3.AsyncAPIObject
-      let sharedOpIdA: string
-      let sharedOpIdB: string
+      let sharedOperationIdA: string
+      let sharedOperationIdB: string
+      let sharedOperationIdC: string
 
       beforeAll(async () => {
-        sharedOpIdA = calculateAsyncOperationId(SHARED_OP_KEY_A, SHARED_MSG_ID_A)
-        sharedOpIdB = calculateAsyncOperationId(SHARED_OP_KEY_B, SHARED_MSG_ID_B)
-        sharedChannelDoc = await loadYamlFile('asyncapi/operations/shared-channel/spec.yaml')
+        sharedOperationIdA = calculateAsyncOperationId(SHARED_ASYNC_OP, SHARED_MESSAGE_ID_A)
+        sharedOperationIdB = calculateAsyncOperationId(SHARED_ASYNC_OP, SHARED_MESSAGE_ID_B)
+        sharedOperationIdC = calculateAsyncOperationId(SHARED_ASYNC_OP, SHARED_MESSAGE_ID_C)
+        const sharedChannelDoc = await loadYamlFile<AsyncAPIV3.AsyncAPIObject>('asyncapi/operations/shared-channel/spec.yaml')
         sharedChannelNormalized = normalizeAsyncApiDocument(sharedChannelDoc)
       })
 
-      test('should include only the relevant message in the operation channel', () => {
-        const result = createOperationSpec(sharedChannelNormalized, sharedOpIdA)
+      test('should include only the relevant message in channel when requesting single operationId', () => {
+        const result = createOperationSpec(sharedChannelNormalized, sharedOperationIdA)
 
-        const operationA = result.operations?.[SHARED_OP_KEY_A] as AsyncAPIV3.OperationObject
-        expect(operationA).toBeDefined()
+        const operation = result.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject
+        expect(operation).toBeDefined()
+        expect(operation.messages).toHaveLength(1)
 
-        const channel = operationA.channel as AsyncAPIV3.ChannelObject
-        const channelMessageKeys = Object.keys(channel.messages ?? {})
-        expect(channelMessageKeys).toEqual([SHARED_MSG_ID_A])
+        const channel = operation.channel as AsyncAPIV3.ChannelObject
+        expect(Object.keys(channel.messages ?? {})).toEqual([SHARED_MESSAGE_ID_A])
       })
 
-      test('should filter channel messages independently per operation', () => {
-        const resultA = createOperationSpec(sharedChannelNormalized, sharedOpIdA)
-        const resultB = createOperationSpec(sharedChannelNormalized, sharedOpIdB)
+      test('should filter channel messages independently per single operationId', () => {
+        const resultA = createOperationSpec(sharedChannelNormalized, sharedOperationIdA)
+        const resultB = createOperationSpec(sharedChannelNormalized, sharedOperationIdB)
 
-        const channelA = (resultA.operations?.[SHARED_OP_KEY_A] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
-        const channelB = (resultB.operations?.[SHARED_OP_KEY_B] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
+        const channelA = (resultA.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
+        const channelB = (resultB.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
 
-        expect(Object.keys(channelA.messages ?? {})).toEqual([SHARED_MSG_ID_A])
-        expect(Object.keys(channelB.messages ?? {})).toEqual([SHARED_MSG_ID_B])
+        expect(Object.keys(channelA.messages ?? {})).toEqual([SHARED_MESSAGE_ID_A])
+        expect(Object.keys(channelB.messages ?? {})).toEqual([SHARED_MESSAGE_ID_B])
+      })
+
+      test('should include only requested messages in channel when requesting multiple operationIds', () => {
+        const result = createOperationSpec(sharedChannelNormalized, [sharedOperationIdA, sharedOperationIdC])
+
+        const operation = result.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject
+        expect(operation).toBeDefined()
+        expect(operation.messages).toHaveLength(2)
+
+        const channel = operation.channel as AsyncAPIV3.ChannelObject
+        const channelMessageKeys = Object.keys(channel.messages ?? {})
+        expect(channelMessageKeys).toEqual(expect.arrayContaining([SHARED_MESSAGE_ID_A, SHARED_MESSAGE_ID_C]))
+        expect(channelMessageKeys).not.toContain(SHARED_MESSAGE_ID_B)
       })
     })
 

--- a/test/asyncapi-operation.test.ts
+++ b/test/asyncapi-operation.test.ts
@@ -301,10 +301,10 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
       expect(result.info).toEqual(normalizedDocument.info)
     })
 
-    test('should not include channels/servers/components by default', () => {
+    test('should not include servers/components by default', () => {
       const result = createOperationSpec(normalizedDocument, OPERATION_ID_1)
 
-      expect(result.channels).toBeUndefined()
+      expect(result.channels).toBeDefined()
       expect(result.servers).toBeUndefined()
       expect(result.components).toBeUndefined()
     })
@@ -417,6 +417,10 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
 
         const channel = operation.channel as AsyncAPIV3.ChannelObject
         expect(Object.keys(channel.messages ?? {})).toEqual([MESSAGE_ID_A])
+
+        // Root channels must contain only the used channel and be the same instance
+        expect(Object.keys(result.channels!)).toEqual(['sharedChannel'])
+        expect(result.channels?.sharedChannel).toBe(channel)
       })
 
       test('should filter channel messages independently per single operationId', () => {
@@ -430,6 +434,12 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
 
         expect(Object.keys(channelA.messages ?? {})).toEqual([MESSAGE_ID_A])
         expect(Object.keys(channelB.messages ?? {})).toEqual([MESSAGE_ID_B])
+
+        // Root channels must contain only the used channel and be the same instance
+        expect(Object.keys(resultA.channels!)).toEqual(['sharedChannel'])
+        expect(Object.keys(resultB.channels!)).toEqual(['sharedChannel'])
+        expect(resultA.channels?.sharedChannel).toBe(channelA)
+        expect(resultB.channels?.sharedChannel).toBe(channelB)
       })
 
       test('should include only requested messages in channel when requesting multiple operationIds', () => {
@@ -450,6 +460,10 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
         const channelMessageKeys = Object.keys(multiMessageOperationChannel.messages ?? {})
         expect(channelMessageKeys).toEqual(expect.arrayContaining([MESSAGE_ID_A, MESSAGE_ID_C, MESSAGE_ID_D]))
         expect(channelMessageKeys).not.toContain(MESSAGE_ID_B)
+
+        // Root channels must contain only the used channel and be the same instance
+        expect(Object.keys(result.channels!)).toEqual(['sharedChannel'])
+        expect(result.channels?.sharedChannel).toBe(multiMessageOperationChannel)
       })
 
       test('should share same channel instance between operations referencing the same channel', () => {
@@ -461,6 +475,10 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
         const operationD = result.operations?.[OPERATION_D] as AsyncAPIV3.OperationObject
 
         expect(multiMessageOperation.channel).toBe(operationD.channel)
+
+        // Root channels must contain only the used channel and be the same instance
+        expect(Object.keys(result.channels!)).toEqual(['sharedChannel'])
+        expect(result.channels?.sharedChannel).toBe(multiMessageOperation.channel)
       })
 
       test('should have different channel instances for operations referencing different channels', () => {
@@ -472,6 +490,13 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
         const operationE = result.operations?.[OPERATION_E] as AsyncAPIV3.OperationObject
 
         expect(multiMessageOperation.channel).not.toBe(operationE.channel)
+
+        // Root channels must contain only the used channels and be the same instances
+        expect(Object.keys(result.channels!)).toEqual(expect.arrayContaining(['sharedChannel', 'otherChannel']))
+        expect(Object.keys(result.channels!)).toHaveLength(2)
+
+        expect(result.channels?.sharedChannel).toBe(multiMessageOperation.channel)
+        expect(result.channels?.otherChannel).toBe(operationE.channel)
       })
 
       test('should have different channel instances when different channels reference the same message', () => {
@@ -484,6 +509,13 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
         const operationF = result.operations?.[OPERATION_F] as AsyncAPIV3.OperationObject
 
         expect(multiMessageOperation.channel).not.toBe(operationF.channel)
+
+        // Root channels must contain only the used channels and be the same instances
+        expect(Object.keys(result.channels!)).toEqual(expect.arrayContaining(['sharedChannel', 'anotherChannelWithSameMessage']))
+        expect(Object.keys(result.channels!)).toHaveLength(2)
+
+        expect(result.channels?.sharedChannel).toBe(multiMessageOperation.channel)
+        expect(result.channels?.anotherChannelWithSameMessage).toBe(operationF.channel)
       })
     })
 

--- a/test/asyncapi-operation.test.ts
+++ b/test/asyncapi-operation.test.ts
@@ -358,58 +358,132 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
       expect(Object.keys(result.operations || {})).toEqual([OPERATION_KEY_1])
     })
 
-    describe('shared channel message filtering', () => {
-      const SHARED_ASYNC_OP = 'multiMessageOp'
-      const SHARED_MESSAGE_ID_A = 'MessageA'
-      const SHARED_MESSAGE_ID_B = 'MessageB'
-      const SHARED_MESSAGE_ID_C = 'MessageC'
+    /**
+     * Tests for channel message filtering in createOperationSpec.
+     *
+     * Setup (shared-channel/spec.yaml):
+     *   - sharedChannel (events/shared): MessageA, MessageB, MessageC, MessageD
+     *   - otherChannel (events/other): MessageE
+     *   - anotherChannelWithSameMessage (events/another): MessageA (same component)
+     *
+     *   - multiMessageOp (send, sharedChannel): MessageA, MessageB, MessageC
+     *   - operationD (receive, sharedChannel): MessageD
+     *   - operationE (send, otherChannel): MessageE
+     *   - operationF (send, anotherChannelWithSameMessage): MessageA
+     *
+     * createOperationSpec must filter channel.messages to only include messages
+     * that are actually requested. Operations sharing the same source channel
+     * must receive the same filtered channel instance.
+     */
+    describe('Shared channel message filtering', () => {
+      const MULTI_MESSAGE_OP = 'multiMessageOp'
+      const OPERATION_D = 'operationD'
+      const OPERATION_E = 'operationE'
+      const OPERATION_F = 'operationF'
+      const MESSAGE_ID_A = 'MessageA'
+      const MESSAGE_ID_B = 'MessageB'
+      const MESSAGE_ID_C = 'MessageC'
+      const MESSAGE_ID_D = 'MessageD'
+      const MESSAGE_ID_E = 'MessageE'
 
       let sharedChannelNormalized: AsyncAPIV3.AsyncAPIObject
-      let sharedOperationIdA: string
-      let sharedOperationIdB: string
-      let sharedOperationIdC: string
+      let operationIdA: string
+      let operationIdB: string
+      let operationIdC: string
+      let operationIdD: string
+      let operationIdE: string
+      let operationIdF: string
 
       beforeAll(async () => {
-        sharedOperationIdA = calculateAsyncOperationId(SHARED_ASYNC_OP, SHARED_MESSAGE_ID_A)
-        sharedOperationIdB = calculateAsyncOperationId(SHARED_ASYNC_OP, SHARED_MESSAGE_ID_B)
-        sharedOperationIdC = calculateAsyncOperationId(SHARED_ASYNC_OP, SHARED_MESSAGE_ID_C)
+        operationIdA = calculateAsyncOperationId(MULTI_MESSAGE_OP, MESSAGE_ID_A)
+        operationIdB = calculateAsyncOperationId(MULTI_MESSAGE_OP, MESSAGE_ID_B)
+        operationIdC = calculateAsyncOperationId(MULTI_MESSAGE_OP, MESSAGE_ID_C)
+        operationIdD = calculateAsyncOperationId(OPERATION_D, MESSAGE_ID_D)
+        operationIdE = calculateAsyncOperationId(OPERATION_E, MESSAGE_ID_E)
+        operationIdF = calculateAsyncOperationId(OPERATION_F, MESSAGE_ID_A)
+
         const sharedChannelDoc = await loadYamlFile<AsyncAPIV3.AsyncAPIObject>('asyncapi/operations/shared-channel/spec.yaml')
         sharedChannelNormalized = normalizeAsyncApiDocument(sharedChannelDoc)
       })
 
       test('should include only the relevant message in channel when requesting single operationId', () => {
-        const result = createOperationSpec(sharedChannelNormalized, sharedOperationIdA)
+        // Request only operationIdA (multiMessageOp + MessageA).
+        // sharedChannel has 4 messages, but the result channel must contain only MessageA.
+        const result = createOperationSpec(sharedChannelNormalized, operationIdA)
 
-        const operation = result.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject
+        const operation = result.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject
         expect(operation).toBeDefined()
         expect(operation.messages).toHaveLength(1)
 
         const channel = operation.channel as AsyncAPIV3.ChannelObject
-        expect(Object.keys(channel.messages ?? {})).toEqual([SHARED_MESSAGE_ID_A])
+        expect(Object.keys(channel.messages ?? {})).toEqual([MESSAGE_ID_A])
       })
 
       test('should filter channel messages independently per single operationId', () => {
-        const resultA = createOperationSpec(sharedChannelNormalized, sharedOperationIdA)
-        const resultB = createOperationSpec(sharedChannelNormalized, sharedOperationIdB)
+        // Two separate calls, each requesting one message from multiMessageOp.
+        // Each result must have its own filtered channel with only the requested message.
+        const resultA = createOperationSpec(sharedChannelNormalized, operationIdA)
+        const resultB = createOperationSpec(sharedChannelNormalized, operationIdB)
 
-        const channelA = (resultA.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
-        const channelB = (resultB.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
+        const channelA = (resultA.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
+        const channelB = (resultB.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
 
-        expect(Object.keys(channelA.messages ?? {})).toEqual([SHARED_MESSAGE_ID_A])
-        expect(Object.keys(channelB.messages ?? {})).toEqual([SHARED_MESSAGE_ID_B])
+        expect(Object.keys(channelA.messages ?? {})).toEqual([MESSAGE_ID_A])
+        expect(Object.keys(channelB.messages ?? {})).toEqual([MESSAGE_ID_B])
       })
 
       test('should include only requested messages in channel when requesting multiple operationIds', () => {
-        const result = createOperationSpec(sharedChannelNormalized, [sharedOperationIdA, sharedOperationIdC])
+        // Request A and C from multiMessageOp + D from operationD — all on sharedChannel.
+        // The shared filtered channel must contain A, C, D but not B.
+        // multiMessageOp gets 2 messages (A, C), operationD gets 1 message (D).
+        const result = createOperationSpec(sharedChannelNormalized, [operationIdA, operationIdC, operationIdD])
 
-        const operation = result.operations?.[SHARED_ASYNC_OP] as AsyncAPIV3.OperationObject
-        expect(operation).toBeDefined()
-        expect(operation.messages).toHaveLength(2)
+        const multiMessageOperation = result.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject
+        expect(multiMessageOperation).toBeDefined()
+        expect(multiMessageOperation.messages).toHaveLength(2)
 
-        const channel = operation.channel as AsyncAPIV3.ChannelObject
-        const channelMessageKeys = Object.keys(channel.messages ?? {})
-        expect(channelMessageKeys).toEqual(expect.arrayContaining([SHARED_MESSAGE_ID_A, SHARED_MESSAGE_ID_C]))
-        expect(channelMessageKeys).not.toContain(SHARED_MESSAGE_ID_B)
+        const operationD = result.operations?.[OPERATION_D] as AsyncAPIV3.OperationObject
+        expect(operationD).toBeDefined()
+        expect(operationD.messages).toHaveLength(1)
+
+        const multiMessageOperationChannel = multiMessageOperation.channel as AsyncAPIV3.ChannelObject
+        const channelMessageKeys = Object.keys(multiMessageOperationChannel.messages ?? {})
+        expect(channelMessageKeys).toEqual(expect.arrayContaining([MESSAGE_ID_A, MESSAGE_ID_C, MESSAGE_ID_D]))
+        expect(channelMessageKeys).not.toContain(MESSAGE_ID_B)
+      })
+
+      test('should share same channel instance between operations referencing the same channel', () => {
+        // multiMessageOp and operationD both reference sharedChannel.
+        // After filtering, they must point to the same channel object (identity check).
+        const result = createOperationSpec(sharedChannelNormalized, [operationIdA, operationIdD])
+
+        const multiMessageOperation = result.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject
+        const operationD = result.operations?.[OPERATION_D] as AsyncAPIV3.OperationObject
+
+        expect(multiMessageOperation.channel).toBe(operationD.channel)
+      })
+
+      test('should have different channel instances for operations referencing different channels', () => {
+        // multiMessageOp references sharedChannel, operationE references otherChannel.
+        // Different source channels → different filtered channel instances.
+        const result = createOperationSpec(sharedChannelNormalized, [operationIdA, operationIdE])
+
+        const multiMessageOperation = result.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject
+        const operationE = result.operations?.[OPERATION_E] as AsyncAPIV3.OperationObject
+
+        expect(multiMessageOperation.channel).not.toBe(operationE.channel)
+      })
+
+      test('should have different channel instances when different channels reference the same message', () => {
+        // multiMessageOp uses MessageA from sharedChannel,
+        // operationF uses the same MessageA component but from anotherChannelWithSameMessage.
+        // Same message component, but different channel objects → different filtered instances.
+        const result = createOperationSpec(sharedChannelNormalized, [operationIdA, operationIdF])
+
+        const multiMessageOperation = result.operations?.[MULTI_MESSAGE_OP] as AsyncAPIV3.OperationObject
+        const operationF = result.operations?.[OPERATION_F] as AsyncAPIV3.OperationObject
+
+        expect(multiMessageOperation.channel).not.toBe(operationF.channel)
       })
     })
 

--- a/test/asyncapi-operation.test.ts
+++ b/test/asyncapi-operation.test.ts
@@ -358,6 +358,47 @@ describe('AsyncAPI 3.0 Operation Tests', () => {
       expect(Object.keys(result.operations || {})).toEqual([OPERATION_KEY_1])
     })
 
+    describe('shared channel message filtering', () => {
+      const SHARED_OP_KEY_A = 'operationA'
+      const SHARED_OP_KEY_B = 'operationB'
+      const SHARED_MSG_ID_A = 'MessageA'
+      const SHARED_MSG_ID_B = 'MessageB'
+
+      let sharedChannelDoc: AsyncAPIV3.AsyncAPIObject
+      let sharedChannelNormalized: AsyncAPIV3.AsyncAPIObject
+      let sharedOpIdA: string
+      let sharedOpIdB: string
+
+      beforeAll(async () => {
+        sharedOpIdA = calculateAsyncOperationId(SHARED_OP_KEY_A, SHARED_MSG_ID_A)
+        sharedOpIdB = calculateAsyncOperationId(SHARED_OP_KEY_B, SHARED_MSG_ID_B)
+        sharedChannelDoc = await loadYamlFile('asyncapi/operations/shared-channel/spec.yaml')
+        sharedChannelNormalized = normalizeAsyncApiDocument(sharedChannelDoc)
+      })
+
+      test('should include only the relevant message in the operation channel', () => {
+        const result = createOperationSpec(sharedChannelNormalized, sharedOpIdA)
+
+        const operationA = result.operations?.[SHARED_OP_KEY_A] as AsyncAPIV3.OperationObject
+        expect(operationA).toBeDefined()
+
+        const channel = operationA.channel as AsyncAPIV3.ChannelObject
+        const channelMessageKeys = Object.keys(channel.messages ?? {})
+        expect(channelMessageKeys).toEqual([SHARED_MSG_ID_A])
+      })
+
+      test('should filter channel messages independently per operation', () => {
+        const resultA = createOperationSpec(sharedChannelNormalized, sharedOpIdA)
+        const resultB = createOperationSpec(sharedChannelNormalized, sharedOpIdB)
+
+        const channelA = (resultA.operations?.[SHARED_OP_KEY_A] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
+        const channelB = (resultB.operations?.[SHARED_OP_KEY_B] as AsyncAPIV3.OperationObject).channel as AsyncAPIV3.ChannelObject
+
+        expect(Object.keys(channelA.messages ?? {})).toEqual([SHARED_MSG_ID_A])
+        expect(Object.keys(channelB.messages ?? {})).toEqual([SHARED_MSG_ID_B])
+      })
+    })
+
     test('should inline referenced channels/servers/components when refsOnlyDocument has inline refs (manual refs)', () => {
       const refsOnlyDocument = {
         operations: {

--- a/test/projects/asyncapi/deprecated/shared-channel-different-deprecation/spec.yaml
+++ b/test/projects/asyncapi/deprecated/shared-channel-different-deprecation/spec.yaml
@@ -1,0 +1,42 @@
+asyncapi: 3.0.0
+info:
+  title: Account Service
+  version: 1.0.0
+channels:
+  channel:
+    address: user/signedup
+    messages:
+      UserSignedUp:
+        $ref: '#/components/messages/UserSignedUp'
+      UserQuit:
+        $ref: '#/components/messages/UserQuit'
+operations:
+  operation1:
+    action: send
+    channel:
+      $ref: '#/channels/channel'
+    messages:
+      - $ref: '#/channels/channel/messages/UserSignedUp'
+  operation2:
+    action: send
+    channel:
+      $ref: '#/channels/channel'
+    messages:
+      - $ref: '#/channels/channel/messages/UserQuit'
+components:
+  messages:
+    UserSignedUp:
+      title: User Signed Up
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+    UserQuit:
+      title: User Quit
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+            deprecated: true

--- a/test/projects/asyncapi/operations/shared-channel/spec.yaml
+++ b/test/projects/asyncapi/operations/shared-channel/spec.yaml
@@ -10,19 +10,17 @@ channels:
         $ref: '#/components/messages/MessageA'
       MessageB:
         $ref: '#/components/messages/MessageB'
+      MessageC:
+        $ref: '#/components/messages/MessageC'
 operations:
-  operationA:
+  multiMessageOp:
     action: send
     channel:
       $ref: '#/channels/sharedChannel'
     messages:
       - $ref: '#/channels/sharedChannel/messages/MessageA'
-  operationB:
-    action: send
-    channel:
-      $ref: '#/channels/sharedChannel'
-    messages:
       - $ref: '#/channels/sharedChannel/messages/MessageB'
+      - $ref: '#/channels/sharedChannel/messages/MessageC'
 components:
   messages:
     MessageA:
@@ -39,3 +37,10 @@ components:
         properties:
           fieldB:
             type: integer
+    MessageC:
+      title: Message C
+      payload:
+        type: object
+        properties:
+          fieldC:
+            type: boolean

--- a/test/projects/asyncapi/operations/shared-channel/spec.yaml
+++ b/test/projects/asyncapi/operations/shared-channel/spec.yaml
@@ -1,0 +1,41 @@
+asyncapi: 3.0.0
+info:
+  title: Shared Channel Test
+  version: 1.0.0
+channels:
+  sharedChannel:
+    address: events/shared
+    messages:
+      MessageA:
+        $ref: '#/components/messages/MessageA'
+      MessageB:
+        $ref: '#/components/messages/MessageB'
+operations:
+  operationA:
+    action: send
+    channel:
+      $ref: '#/channels/sharedChannel'
+    messages:
+      - $ref: '#/channels/sharedChannel/messages/MessageA'
+  operationB:
+    action: send
+    channel:
+      $ref: '#/channels/sharedChannel'
+    messages:
+      - $ref: '#/channels/sharedChannel/messages/MessageB'
+components:
+  messages:
+    MessageA:
+      title: Message A
+      payload:
+        type: object
+        properties:
+          fieldA:
+            type: string
+    MessageB:
+      title: Message B
+      payload:
+        type: object
+        properties:
+          fieldB:
+            type: integer

--- a/test/projects/asyncapi/operations/shared-channel/spec.yaml
+++ b/test/projects/asyncapi/operations/shared-channel/spec.yaml
@@ -12,6 +12,18 @@ channels:
         $ref: '#/components/messages/MessageB'
       MessageC:
         $ref: '#/components/messages/MessageC'
+      MessageD:
+        $ref: '#/components/messages/MessageD'
+  otherChannel:
+    address: events/other
+    messages:
+      MessageE:
+        $ref: '#/components/messages/MessageE'
+  anotherChannelWithSameMessage:
+    address: events/another
+    messages:
+      MessageA:
+        $ref: '#/components/messages/MessageA'
 operations:
   multiMessageOp:
     action: send
@@ -21,6 +33,24 @@ operations:
       - $ref: '#/channels/sharedChannel/messages/MessageA'
       - $ref: '#/channels/sharedChannel/messages/MessageB'
       - $ref: '#/channels/sharedChannel/messages/MessageC'
+  operationD:
+    action: receive
+    channel:
+      $ref: '#/channels/sharedChannel'
+    messages:
+      - $ref: '#/channels/sharedChannel/messages/MessageD'
+  operationE:
+    action: send
+    channel:
+      $ref: '#/channels/otherChannel'
+    messages:
+      - $ref: '#/channels/otherChannel/messages/MessageE'
+  operationF:
+    action: send
+    channel:
+      $ref: '#/channels/anotherChannelWithSameMessage'
+    messages:
+      - $ref: '#/channels/anotherChannelWithSameMessage/messages/MessageA'
 components:
   messages:
     MessageA:
@@ -44,3 +74,17 @@ components:
         properties:
           fieldC:
             type: boolean
+    MessageD:
+      title: Message D
+      payload:
+        type: object
+        properties:
+          fieldD:
+            type: boolean
+    MessageE:
+      title: Message E
+      payload:
+        type: object
+        properties:
+          fieldE:
+            type: string


### PR DESCRIPTION
- Fixed deprecated items leaking between AsyncAPI operations that share the same channel but use different messages                                                                                                                                                                                              
- Extracted `filterChannelMessages` utility in `async.utils.ts` to filter channel messages per operation in `createOperationSpec`                                                                                                                                                                                  
- Added tests for deprecated items isolation and channel message filtering  