### PR TITLE
fix: report added operation messages when a new AsyncAPI specification is added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.0",
+        "@asyncapi/parser": "3.6.0",
         "@netcracker/qubership-apihub-api-diff": "3.1.0",
         "@netcracker/qubership-apihub-api-unifier": "2.7.0",
         "@netcracker/qubership-apihub-graphapi": "1.0.9",
@@ -79,12 +79,12 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.4.0.tgz",
-      "integrity": "sha512-Sxn74oHiZSU6+cVeZy62iPZMFMvKp4jupMFHelSICCMw1qELmUHPvuZSr+ZHDmNGgHcEpzJM5HN02kR7T4g+PQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.6.0.tgz",
+      "integrity": "sha512-6S0Yr8vI418a1IrpGsOYbfWVo9+aHvSqN2oSkiY0YJltS/C7oDOt9e0mo6hSld8bg+EeKrtgkVmpW4obh1JFvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/specs": "^6.8.0",
+        "@asyncapi/specs": "^6.11.1",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "3.21.0",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,8 +100,8 @@
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.0.0",
+        "js-yaml": "^4.1.1",
+        "jsonpath-plus": "^10.0.7",
         "node-fetch": "2.6.7"
       }
     },
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.10.0.tgz",
-      "integrity": "sha512-vB5oKLsdrLUORIZ5BXortZTlVyGWWMC1Nud/0LtgxQ3Yn2738HigAD6EVqScvpPsDUI/bcLVsYEXN4dtXQHVng==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.11.1.tgz",
+      "integrity": "sha512-A3WBLqAKGoJ2+6FWFtpjBlCQ1oFCcs4GxF7zsIGvNqp/klGUHjlA3aAcZ9XMMpLGE8zPeYDz2x9FmO6DSuKraQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
@@ -6481,9 +6481,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.0",
+    "@asyncapi/parser": "3.6.0",
     "@netcracker/qubership-apihub-api-diff": "next",
     "@netcracker/qubership-apihub-api-unifier": "2.7.0",
     "@netcracker/qubership-apihub-graphapi": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@asyncapi/parser": "3.6.0",
-    "@netcracker/qubership-apihub-api-diff": "next",
+    "@netcracker/qubership-apihub-api-diff": "bugfix-asyncapi-publish-error",
     "@netcracker/qubership-apihub-api-unifier": "2.7.0",
     "@netcracker/qubership-apihub-graphapi": "1.0.9",
     "@netcracker/qubership-apihub-json-crawl": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@asyncapi/parser": "3.6.0",
-    "@netcracker/qubership-apihub-api-diff": "bugfix-asyncapi-publish-error",
+    "@netcracker/qubership-apihub-api-diff": "next",
     "@netcracker/qubership-apihub-api-unifier": "2.7.0",
     "@netcracker/qubership-apihub-graphapi": "1.0.9",
     "@netcracker/qubership-apihub-json-crawl": "1.2.0",

--- a/src/apitypes/async/async.changes.ts
+++ b/src/apitypes/async/async.changes.ts
@@ -224,7 +224,7 @@ function createCopyWithEmptyOperations(template: AsyncAPIV3.AsyncAPIObject): Asy
 
   return {
     operations: operations ? Object.fromEntries(
-      Object.keys(operations).map(key => [key, {} as AsyncAPIV3.OperationObject]),
+      Object.entries(operations).map(([key, operation]) => [key, { ...operation, messages: [] }]),
     ) : {},
     ...rest,
   }

--- a/src/apitypes/async/async.parser.ts
+++ b/src/apitypes/async/async.parser.ts
@@ -21,6 +21,7 @@ import { ASYNC_DOCUMENT_TYPE, ASYNC_FILE_FORMAT } from './async.consts'
 import { FILE_KIND, TextFile } from '../../types'
 import { getFileExtension } from '../../utils'
 import { v3 as AsyncAPIV3 } from '@asyncapi/parser/esm/spec-types'
+import { RulesetOptions } from '@asyncapi/parser/esm/ruleset'
 
 interface ValidationError {
   message: string
@@ -114,6 +115,20 @@ async function getParserClass(): Promise<typeof Parser> {
 }
 
 /**
+ * Parser ruleset options with intentionally suppressed rules.
+ *
+ * asyncapi-latest-version: fires when the document uses AsyncAPI 3.0.0 instead of the newest
+ * version known to the parser. We support 3.0.0 documents and do not want to treat
+ * "not the latest version" as an error or warning.
+ */
+const ASYNCAPI_PARSER_RULESET: RulesetOptions = {
+  extends: [],
+  rules: {
+    'asyncapi-latest-version': 'off',
+  },
+}
+
+/**
  * Validates AsyncAPI document using official parser.
  * This provides spec validation while avoiding circular reference issues
  * by using the parser only for validation, not for the actual parsing.
@@ -124,7 +139,7 @@ async function getParserClass(): Promise<typeof Parser> {
 async function validateAsyncApiDocument(sourceString: string): Promise<ValidationError[] | undefined> {
   try {
     const ParserClass = await getParserClass()
-    const parser: Parser = new ParserClass()
+    const parser: Parser = new ParserClass({ ruleset: ASYNCAPI_PARSER_RULESET })
     const { diagnostics }: ParseOutput = await parser.parse(sourceString)
 
     const criticalErrors: Diagnostic[] = diagnostics.filter(diagnostic => diagnostic.severity === 0)

--- a/test/asyncapi-changes.test.ts
+++ b/test/asyncapi-changes.test.ts
@@ -51,6 +51,30 @@ describe('AsyncAPI 3.0 Changelog tests', () => {
       ]))
     })
 
+    test('should report added operations from a new AsyncAPI document', async () => {
+      const result = await buildChangelogPackageDefaultConfig(
+        'asyncapi-changes/operation/add-async-new-document',
+        [{ fileId: 'before/rest.yaml' }],
+        [
+          { fileId: 'after/rest.yaml' },
+          { fileId: 'after/async.yaml' },
+        ],
+      )
+
+      expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 2 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(numberOfImpactedOperationsMatcher({ [NON_BREAKING_CHANGE_TYPE]: 2 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(operationChangesMatcher([
+        expect.objectContaining({
+          operationId: 'operation1-message1',
+          changeSummary: expect.objectContaining({ [NON_BREAKING_CHANGE_TYPE]: 1 }),
+        }),
+        expect.objectContaining({
+          operationId: 'operation2-message2',
+          changeSummary: expect.objectContaining({ [NON_BREAKING_CHANGE_TYPE]: 1 }),
+        }),
+      ]))
+    })
+
     test('should report added operation with multiple messages', async () => {
       const result = await buildChangelogPackageDefaultConfig('asyncapi-changes/operation/add-with-multiple-messages')
       expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))

--- a/test/asyncapi-changes.test.ts
+++ b/test/asyncapi-changes.test.ts
@@ -449,7 +449,7 @@ describe('AsyncAPI 3.0 Changelog tests', () => {
     test('should report added APIHUB operation when message reference is added to async operation', async () => {
       const result = await buildChangelogPackageDefaultConfig('asyncapi-changes/message/add-to-operation')
 
-      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
       expect(result).toEqual(operationChangesMatcher([
         expect.objectContaining({ operationId: 'operation1-message2' }),
       ]))
@@ -458,7 +458,7 @@ describe('AsyncAPI 3.0 Changelog tests', () => {
     test('should report removed APIHUB operation when message reference is removed from async operation', async () => {
       const result = await buildChangelogPackageDefaultConfig('asyncapi-changes/message/remove-from-operation')
 
-      expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
       expect(result).toEqual(operationChangesMatcher([
         expect.objectContaining({ previousOperationId: 'operation1-message2' }),
       ]))
@@ -481,7 +481,7 @@ describe('AsyncAPI 3.0 Changelog tests', () => {
 
       // message2 added to operation1, operation2 unchanged
       // should only impact 1 new apihub operation (operation1-message2)
-      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
       expect(result).toEqual(operationChangesMatcher([
         expect.objectContaining({
           operationId: 'operation1-message2',
@@ -495,7 +495,7 @@ describe('AsyncAPI 3.0 Changelog tests', () => {
       // Removing message2 from operation with message1, message2, message3
       // should only impact 1 removed apihub operation (operation1-message2),
       // not the remaining operation1-message1 and operation1-message3
-      expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
       expect(result).toEqual(operationChangesMatcher([
         expect.objectContaining({
           previousOperationId: 'operation1-message2',
@@ -541,7 +541,7 @@ describe('AsyncAPI 3.0 Changelog tests', () => {
       // not on existing operation1-message1 or operation1-message2.
       const result = await buildChangelogPackageDefaultConfig('asyncapi-changes/message/add-message-no-sibling-impact')
 
-      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
+      expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, ASYNCAPI_API_TYPE))
       expect(result).toEqual(operationChangesMatcher([
         expect.objectContaining({
           operationId: 'operation1-message3',

--- a/test/projects/asyncapi-changes/operation/add-async-new-document/after/async.yaml
+++ b/test/projects/asyncapi-changes/operation/add-async-new-document/after/async.yaml
@@ -1,0 +1,39 @@
+asyncapi: 3.0.0
+info:
+  title: Test AsyncAPI
+  version: 1.0.0
+channels:
+  channel1:
+    address: channel1
+    messages:
+      message1:
+        $ref: "#/components/messages/message1"
+      message2:
+        $ref: "#/components/messages/message2"
+operations:
+  operation1:
+    action: send
+    channel:
+      $ref: "#/channels/channel1"
+    messages:
+      - $ref: "#/channels/channel1/messages/message1"
+  operation2:
+    action: receive
+    channel:
+      $ref: "#/channels/channel1"
+    messages:
+      - $ref: "#/channels/channel1/messages/message2"
+components:
+  messages:
+    message1:
+      payload:
+        type: object
+        properties:
+          userId:
+            type: string
+    message2:
+      payload:
+        type: object
+        properties:
+          userId:
+            type: string

--- a/test/projects/asyncapi-changes/operation/add-async-new-document/after/rest.yaml
+++ b/test/projects/asyncapi-changes/operation/add-async-new-document/after/rest.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Test REST API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      responses:
+        "200":
+          description: OK
+          content: {}

--- a/test/projects/asyncapi-changes/operation/add-async-new-document/before/rest.yaml
+++ b/test/projects/asyncapi-changes/operation/add-async-new-document/before/rest.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Test REST API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      responses:
+        "200":
+          description: OK
+          content: {}


### PR DESCRIPTION
chore: change expected result for changes to AsyncAPI operations and messages to account for changes in api-diff
fix: update asyncapi parser version