### PR TITLE
chore: normalize public contacts and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please, follow these guidelines to make the contribution process easy and effect
 
 ## Contributor License Agreement
 
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
-# Security Reporting Process
+# Security Policy
+
+## Reporting a Vulnerability
 
 Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
 
 If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
-# Security Release Process
+## Security Release Process
 
 If the vulnerability is found in the latest stable release, then it would be fixed in patch version for that release.
 E.g., issue is found in 2.5.0 release, then 2.5.1 version with a fix will be released.

--- a/test/projects/agent/PublicRegistry API(4).yaml
+++ b/test/projects/agent/PublicRegistry API(4).yaml
@@ -241,7 +241,7 @@ paths:
                         userName:
                           description: Name of the user who generated an event
                           type: string
-                          example: "Name Surname"
+                          example: "John Doe"
                         userId:
                           description: Login of the user who generated an event
                           type: string
@@ -295,7 +295,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -314,7 +314,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -559,7 +559,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -578,7 +578,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -826,7 +826,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -845,7 +845,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -1544,7 +1544,7 @@ paths:
                         userName:
                           description: Name of the user who generated an event
                           type: string
-                          example: "Name Surname"
+                          example: "John Doe"
                         userId:
                           description: Login of the user who generated an event
                           type: string
@@ -1598,7 +1598,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -1617,7 +1617,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -1859,7 +1859,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -1878,7 +1878,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -2124,7 +2124,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -2143,7 +2143,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -8453,11 +8453,11 @@ paths:
                   description: Email address of the user
                   type: string
                   format: email
-                  example: "name.surname@qubership.org"
+                  example: "john.doe@example.com"
                 name:
                   description: Name of the user
                   type: string
-                  example: "Name Surname"
+                  example: "John Doe"
                 password:
                   type: string
                   description: User password.
@@ -13510,12 +13510,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: Avatar of the user
           type: string
@@ -13618,7 +13618,7 @@ components:
           items:
             type: string
             format: email
-          example: ["name.surname@qubership.org"]
+          example: ["john.doe@example.com"]
         roleIds:
           type: array
           description: List of role IDs, added to the user.

--- a/test/projects/apihub/Public Registry API.yaml
+++ b/test/projects/apihub/Public Registry API.yaml
@@ -241,7 +241,7 @@ paths:
                         userName:
                           description: Name of the user who generated an event
                           type: string
-                          example: "Name Surname"
+                          example: "John Doe"
                         userId:
                           description: Login of the user who generated an event
                           type: string
@@ -295,7 +295,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -314,7 +314,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -559,7 +559,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -578,7 +578,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -826,7 +826,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -845,7 +845,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -1544,7 +1544,7 @@ paths:
                         userName:
                           description: Name of the user who generated an event
                           type: string
-                          example: "Name Surname"
+                          example: "John Doe"
                         userId:
                           description: Login of the user who generated an event
                           type: string
@@ -1598,7 +1598,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -1617,7 +1617,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -1859,7 +1859,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -1878,7 +1878,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -2124,7 +2124,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -2143,7 +2143,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -8453,11 +8453,11 @@ paths:
                   description: Email address of the user
                   type: string
                   format: email
-                  example: "name.surname@qubership.org"
+                  example: "john.doe@example.com"
                 name:
                   description: Name of the user
                   type: string
-                  example: "Name Surname"
+                  example: "John Doe"
                 password:
                   type: string
                   description: User password.
@@ -13510,12 +13510,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: Avatar of the user
           type: string
@@ -13618,7 +13618,7 @@ components:
           items:
             type: string
             format: email
-          example: ["name.surname@qubership.org"]
+          example: ["john.doe@example.com"]
         roleIds:
           type: array
           description: List of role IDs, added to the user.

--- a/test/projects/deprecated/PublicRegistry API(4).yaml
+++ b/test/projects/deprecated/PublicRegistry API(4).yaml
@@ -830,12 +830,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: Avatar of the user
           type: string
@@ -938,7 +938,7 @@ components:
           items:
             type: string
             format: email
-          example: ["name.surname@qubership.org"]
+          example: ["john.doe@example.com"]
         roleIds:
           type: array
           description: List of role IDs, added to the user.

--- a/test/projects/deprecated/PublicRegistry API(4)v2.yaml
+++ b/test/projects/deprecated/PublicRegistry API(4)v2.yaml
@@ -835,12 +835,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: Avatar of the user
           type: string
@@ -943,7 +943,7 @@ components:
           items:
             type: string
             format: email
-          example: ["name.surname@qubership.org"]
+          example: ["john.doe@example.com"]
         roleIds:
           type: array
           description: List of role IDs, added to the user.

--- a/test/projects/deprecated/PublicRegistry API(4)v3.yaml
+++ b/test/projects/deprecated/PublicRegistry API(4)v3.yaml
@@ -777,12 +777,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: Avatar of the user
           type: string
@@ -885,7 +885,7 @@ components:
           items:
             type: string
             format: email
-          example: ["name.surname@qubership.org"]
+          example: ["john.doe@example.com"]
         roleIds:
           type: array
           description: List of role IDs, added to the user.


### PR DESCRIPTION
## Summary

- Normalize public contact files and example email addresses.
- Keep API support and repository feedback contacts aligned with approved addresses.
- Replace personal-looking examples with neutral example data where applicable.

## Changed files

- CONTRIBUTING.md
- SECURITY.md
- test/projects/agent/PublicRegistry API(4).yaml
- test/projects/apihub/Public Registry API.yaml
- test/projects/deprecated/PublicRegistry API(4).yaml
- test/projects/deprecated/PublicRegistry API(4)v2.yaml
- test/projects/deprecated/PublicRegistry API(4)v3.yaml

## Commit

3b8a483 chore: normalize public contacts and examples
 CONTRIBUTING.md                                    |  2 +-
 SECURITY.md                                        |  6 ++--
 test/projects/agent/PublicRegistry API(4).yaml     | 38 +++++++++++-----------
 test/projects/apihub/Public Registry API.yaml      | 38 +++++++++++-----------
 .../projects/deprecated/PublicRegistry API(4).yaml |  6 ++--
 .../deprecated/PublicRegistry API(4)v2.yaml        |  6 ++--
 .../deprecated/PublicRegistry API(4)v3.yaml        |  6 ++--
 7 files changed, 52 insertions(+), 50 deletions(-)
