### PR TITLE
feat: support no-BWC / experimental apiKind for GraphQL API Changes

### DIFF
--- a/src/apitypes/graphql/graphql.changes.ts
+++ b/src/apitypes/graphql/graphql.changes.ts
@@ -50,6 +50,8 @@ import {
   getOperationTags,
   OperationsMap,
 } from '../../components'
+import { calculateApiKindFromLabels } from '../../components/document'
+import { createGraphqlApiCompatibilityScopeFunction } from '../../components/compare/graphql.bwc.validation'
 
 export const compareDocuments: DocumentsCompare = async (
   operationsMap: OperationsMap,
@@ -57,7 +59,15 @@ export const compareDocuments: DocumentsCompare = async (
   currDoc: ResolvedVersionDocument | undefined,
   ctx: CompareOperationsPairContext,
 ): Promise<DocumentsCompareData> => {
-  const { apiType, rawDocumentResolver, previousVersion, currentVersion, previousPackageId, currentPackageId } = ctx
+  const {
+    apiType,
+    rawDocumentResolver,
+    previousVersion,
+    currentVersion,
+    previousPackageId,
+    currentPackageId,
+    previousVersionLabels,
+  } = ctx
   const comparisonInternalDocumentId = createComparisonInternalDocumentId(previousVersion, previousPackageId, prevDoc?.slug, currentVersion, currentPackageId, currDoc?.slug)
   const prevFile = prevDoc && await rawDocumentResolver(previousVersion, previousPackageId, prevDoc.slug)
   const currFile = currDoc && await rawDocumentResolver(currentVersion, currentPackageId, currDoc.slug)
@@ -84,6 +94,9 @@ export const compareDocuments: DocumentsCompare = async (
     currDocData = getCopyWithEmptyOperations(prevDocData)
   }
 
+  const currDocumentApiKind = currDoc?.apiKind
+  const prevDocumentApiKind = prevDoc?.apiKind || calculateApiKindFromLabels(prevDoc?.labels, previousVersionLabels)
+
   const { merged, diffs } = apiDiff(
     prevDocData,
     currDocData,
@@ -94,6 +107,7 @@ export const compareDocuments: DocumentsCompare = async (
       normalizedResult: true,
       afterValueNormalizedProperty: AFTER_VALUE_NORMALIZED_PROPERTY,
       beforeValueNormalizedProperty: BEFORE_VALUE_NORMALIZED_PROPERTY,
+      apiCompatibilityScopeFunction: createGraphqlApiCompatibilityScopeFunction(prevDocumentApiKind, currDocumentApiKind),
     },
   ) as { merged: GraphApiSchema; diffs: Diff[] }
 

--- a/src/apitypes/graphql/graphql.changes.ts
+++ b/src/apitypes/graphql/graphql.changes.ts
@@ -95,6 +95,8 @@ export const compareDocuments: DocumentsCompare = async (
   }
 
   const currDocumentApiKind = currDoc?.apiKind
+  // ApiKind is not guaranteed for the previous document: it is downloaded data and the field is optional.
+  // In this case, we calculate ApiKind by labels (file then version) in order of priority.
   const prevDocumentApiKind = prevDoc?.apiKind || calculateApiKindFromLabels(prevDoc?.labels, previousVersionLabels)
 
   const { merged, diffs } = apiDiff(

--- a/src/components/compare/async.bwc.validation.ts
+++ b/src/components/compare/async.bwc.validation.ts
@@ -17,17 +17,13 @@
 import {
   APIHUB_API_COMPATIBILITY_KIND_BWC,
   ApihubApiCompatibilityKind,
-  isNoBwcLike,
 } from '../../consts'
 import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
-import {
-  API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE,
-  API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE,
-  ApiCompatibilityKind,
-} from '@netcracker/qubership-apihub-api-diff'
+import { ApiCompatibilityKind } from '@netcracker/qubership-apihub-api-diff'
 import { getApiKindProperty } from '../document'
 import { v3 as AsyncAPIV3 } from '@asyncapi/parser/esm/spec-types'
 import { ApiCompatibilityScopeFunctionFactory } from './bwc.validation.types'
+import { toApiCompatibilityKind } from './bwc.validation.utils'
 
 const ROOT_PATH_LENGTH = 0
 const ASYNC_OPERATION_PATH_LENGTH = 2 // operations/<operationId>
@@ -44,14 +40,6 @@ const resolveEffectiveApiKind = (
   return operationKind ?? channelKind ?? documentKind
 }
 
-const toApiCompatibilityKind = (
-  beforeKind: ApihubApiCompatibilityKind,
-  afterKind: ApihubApiCompatibilityKind,
-): ApiCompatibilityKind => {
-  return (isNoBwcLike(beforeKind) || isNoBwcLike(afterKind))
-    ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
-    : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
-}
 
 /**
  * Creates an ApiCompatibilityScopeFunction for AsyncAPI documents.

--- a/src/components/compare/bwc.validation.utils.ts
+++ b/src/components/compare/bwc.validation.utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApihubApiCompatibilityKind, isNoBwcLike } from '../../consts'
+import {
+  API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE,
+  API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE,
+  ApiCompatibilityKind,
+} from '@netcracker/qubership-apihub-api-diff'
+
+/**
+ * Maps one or more resolved api-kinds to an api-diff compatibility scope:
+ * NOT backward compatible (→ risky) if ANY of the given api-kinds is no-bwc-like,
+ * otherwise backward compatible (→ breaking stays breaking).
+ *
+ * Shared by the REST/GraphQL/AsyncAPI bwc scope functions — pass a single kind
+ * (e.g. removal keyed on the previous kind) or several (e.g. either-side modification).
+ */
+export const toApiCompatibilityKind = (...apiKinds: (ApihubApiCompatibilityKind | undefined)[]): ApiCompatibilityKind =>
+  (apiKinds.some(isNoBwcLike)
+    ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
+    : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE)

--- a/src/components/compare/graphql.bwc.validation.ts
+++ b/src/components/compare/graphql.bwc.validation.ts
@@ -46,7 +46,7 @@ export const createGraphqlApiCompatibilityScopeFunction: ApiCompatibilityScopeFu
   prevDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
   currDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
 ) => {
-  const modificationApiCompatibilityKind = toApiCompatibilityKind(prevDocumentApiKind, currDocumentApiKind)
+  const defaultApiCompatibilityKind = toApiCompatibilityKind(prevDocumentApiKind, currDocumentApiKind)
 
   return (
     path?: JsonPath,
@@ -56,7 +56,7 @@ export const createGraphqlApiCompatibilityScopeFunction: ApiCompatibilityScopeFu
     const pathLength = path?.length ?? 0
 
     if (pathLength === ROOT_PATH_LENGTH) {
-      return modificationApiCompatibilityKind
+      return defaultApiCompatibilityKind
     }
 
     // queries|mutations|subscriptions/<operationName>
@@ -72,7 +72,7 @@ export const createGraphqlApiCompatibilityScopeFunction: ApiCompatibilityScopeFu
         return toApiCompatibilityKind(prevDocumentApiKind)
       }
 
-      return modificationApiCompatibilityKind
+      return defaultApiCompatibilityKind
     }
 
     return undefined

--- a/src/components/compare/graphql.bwc.validation.ts
+++ b/src/components/compare/graphql.bwc.validation.ts
@@ -14,30 +14,18 @@
  * limitations under the License.
  */
 
-import {
-  APIHUB_API_COMPATIBILITY_KIND_BWC,
-  ApihubApiCompatibilityKind,
-  isNoBwcLike,
-} from '../../consts'
+import { APIHUB_API_COMPATIBILITY_KIND_BWC } from '../../consts'
 import { isObject } from '../../utils'
 import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
-import {
-  API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE,
-  API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE,
-  ApiCompatibilityKind,
-} from '@netcracker/qubership-apihub-api-diff'
+import { ApiCompatibilityKind } from '@netcracker/qubership-apihub-api-diff'
 import { GRAPHQL_TYPE_KEYS } from '../../apitypes/graphql/graphql.consts'
 import { ApiCompatibilityScopeFunctionFactory } from './bwc.validation.types'
+import { toApiCompatibilityKind } from './bwc.validation.utils'
 
 const ROOT_PATH_LENGTH = 0
 const GRAPHQL_OPERATION_PATH_LENGTH = 2 // queries|mutations|subscriptions/<operationName>
 
 const OPERATION_ROOT_SEGMENTS: ReadonlySet<string> = new Set(GRAPHQL_TYPE_KEYS)
-
-const toApiCompatibilityKind = (documentApiKind: ApihubApiCompatibilityKind): ApiCompatibilityKind =>
-  (isNoBwcLike(documentApiKind)
-    ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
-    : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE)
 
 /**
  * Creates an ApiCompatibilityScopeFunction for GraphQL documents.
@@ -47,17 +35,18 @@ const toApiCompatibilityKind = (documentApiKind: ApihubApiCompatibilityKind): Ap
  * api-kind. Because of that this function never inspects per-node markers — it
  * uses the resolved document api-kinds directly.
  *
- * Classification:
- * - modification (operation exists on both sides, or root-level document change):
- *     severity is keyed on the CURRENT document api-kind.
- * - removal (operation exists before, absent after):
- *     severity is keyed on the PREVIOUS document api-kind.
+ * Classification (consistent with REST/async):
+ * - modification (operation exists on both sides, an added operation, or a root-level
+ *     document change): risky if EITHER the previous or the current document api-kind
+ *     is no-bwc-like.
+ * - removal (operation exists before, absent after): keyed on the PREVIOUS document
+ *     api-kind.
  */
 export const createGraphqlApiCompatibilityScopeFunction: ApiCompatibilityScopeFunctionFactory = (
   prevDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
   currDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
 ) => {
-  const modificationApiCompatibilityKind = toApiCompatibilityKind(currDocumentApiKind)
+  const modificationApiCompatibilityKind = toApiCompatibilityKind(prevDocumentApiKind, currDocumentApiKind)
 
   return (
     path?: JsonPath,

--- a/src/components/compare/graphql.bwc.validation.ts
+++ b/src/components/compare/graphql.bwc.validation.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  APIHUB_API_COMPATIBILITY_KIND_BWC,
+  ApihubApiCompatibilityKind,
+  isNoBwcLike,
+} from '../../consts'
+import { isObject } from '../../utils'
+import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
+import {
+  API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE,
+  API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE,
+  ApiCompatibilityKind,
+} from '@netcracker/qubership-apihub-api-diff'
+import { GRAPHQL_TYPE_KEYS } from '../../apitypes/graphql/graphql.consts'
+import { ApiCompatibilityScopeFunctionFactory } from './bwc.validation.types'
+
+const ROOT_PATH_LENGTH = 0
+const GRAPHQL_OPERATION_PATH_LENGTH = 2 // queries|mutations|subscriptions/<operationName>
+
+const OPERATION_ROOT_SEGMENTS: ReadonlySet<string> = new Set(GRAPHQL_TYPE_KEYS)
+
+const toApiCompatibilityKind = (documentApiKind: ApihubApiCompatibilityKind): ApiCompatibilityKind =>
+  (isNoBwcLike(documentApiKind)
+    ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
+    : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE)
+
+/**
+ * Creates an ApiCompatibilityScopeFunction for GraphQL documents.
+ *
+ * GraphQL api-kind is document-level only: there is no per-operation `x-api-kind`
+ * in the SDL (out of scope), so every operation inherits the document
+ * api-kind. Because of that this function never inspects per-node markers — it
+ * uses the resolved document api-kinds directly.
+ *
+ * Classification:
+ * - modification (operation exists on both sides, or root-level document change):
+ *     severity is keyed on the CURRENT document api-kind.
+ * - removal (operation exists before, absent after):
+ *     severity is keyed on the PREVIOUS document api-kind.
+ */
+export const createGraphqlApiCompatibilityScopeFunction: ApiCompatibilityScopeFunctionFactory = (
+  prevDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
+  currDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
+) => {
+  const modificationApiCompatibilityKind = toApiCompatibilityKind(currDocumentApiKind)
+
+  return (
+    path?: JsonPath,
+    beforeJson?: unknown,
+    afterJson?: unknown,
+  ): ApiCompatibilityKind | undefined => {
+    const pathLength = path?.length ?? 0
+
+    if (pathLength === ROOT_PATH_LENGTH) {
+      return modificationApiCompatibilityKind
+    }
+
+    // queries|mutations|subscriptions/<operationName>
+    if (pathLength === GRAPHQL_OPERATION_PATH_LENGTH && OPERATION_ROOT_SEGMENTS.has(String(path?.[0]))) {
+      const beforeExists = isObject(beforeJson)
+      const afterExists = isObject(afterJson)
+
+      if (!beforeExists && !afterExists) {
+        return undefined
+      }
+
+      if (beforeExists && !afterExists) {
+        return toApiCompatibilityKind(prevDocumentApiKind)
+      }
+
+      return modificationApiCompatibilityKind
+    }
+
+    return undefined
+  }
+}

--- a/src/components/compare/rest.bwc.validation.ts
+++ b/src/components/compare/rest.bwc.validation.ts
@@ -30,6 +30,7 @@ import {
 import { getApiKindProperty } from '../document'
 import { OpenAPIV3 } from 'openapi-types'
 import { ApiCompatibilityScopeFunctionFactory } from './bwc.validation.types'
+import { toApiCompatibilityKind } from './bwc.validation.utils'
 
 export const calculateOperationApiCompatibilityKind = (
   beforeOperationObject: OpenAPIV3.OperationObject | undefined,
@@ -43,16 +44,10 @@ export const calculateOperationApiCompatibilityKind = (
 
   // Handle operation removal: compatibility depends on the removed operation's kind
   if (isOperationRemoved) {
-    return isNoBwcLike(beforeKind)
-      ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
-      : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+    return toApiCompatibilityKind(beforeKind)
   }
 
-  if (isNoBwcLike(beforeKind) || isNoBwcLike(afterKind)) {
-    return API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
-  }
-
-  return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+  return toApiCompatibilityKind(beforeKind, afterKind)
 }
 
 export const getMethodsApiCompatibilityKind = (pathItemObject: OpenAPIV3.PathItemObject, prevDocumentApiKind: ApihubApiCompatibilityKind): ApiCompatibilityKind => {
@@ -65,9 +60,7 @@ export const getMethodsApiCompatibilityKind = (pathItemObject: OpenAPIV3.PathIte
     return API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
   }
 
-  return isNoBwcLike(prevDocumentApiKind)
-    ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
-    : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+  return toApiCompatibilityKind(prevDocumentApiKind)
 }
 
 const checkAllMethodsMatchApiKind = (obj: OpenAPIV3.PathItemObject, predicate: (kind: ApihubApiCompatibilityKind | undefined) => boolean): boolean => {
@@ -92,9 +85,7 @@ export const createRestApiCompatibilityScopeFunction: ApiCompatibilityScopeFunct
   prevDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
   currDocumentApiKind = APIHUB_API_COMPATIBILITY_KIND_BWC,
 ) => {
-  const defaultApiCompatibilityKind = (isNoBwcLike(prevDocumentApiKind) || isNoBwcLike(currDocumentApiKind))
-    ? API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
-    : API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+  const defaultApiCompatibilityKind = toApiCompatibilityKind(prevDocumentApiKind, currDocumentApiKind)
 
   return (
     path?: JsonPath,

--- a/test/graphql-build-apikind.test.ts
+++ b/test/graphql-build-apikind.test.ts
@@ -27,7 +27,11 @@ const BWC = APIHUB_API_COMPATIBILITY_KIND_BWC
 const NO_BWC = APIHUB_API_COMPATIBILITY_KIND_NO_BWC
 
 const FILE_ID = 'spec.gql'
-const SDL = 'type Query {\n  fruits: String\n  vegetables: String\n}' // two operations
+// Two operations
+const SPEC = `type Query {
+  fruits: String
+  vegetables: String
+}`
 
 // Difference from `apiKinds.test.ts`:
 //   - `apiKinds.test.ts` covers REST and asserts only the DOCUMENT apiKind, exhaustively
@@ -50,7 +54,7 @@ describe('GraphQL build api-kind', () => {
     { id: 'file-nb', desc: 'file label no-BWC', fileLabels: ['apihub/x-api-kind: no-BWC'], expected: NO_BWC },
     { id: 'version-nb', desc: 'version label no-BWC', versionLabels: ['apihub/x-api-kind: no-BWC'], expected: NO_BWC },
   ])('should apply $desc to the document and all its operations', async ({ id, fileLabels, versionLabels, expected }) => {
-    const result = await buildPackageFromContent(`gql-build-apikind/${id}`, FILE_ID, SDL, fileLabels, versionLabels)
+    const result = await buildPackageFromContent(`gql-build-apikind/${id}`, FILE_ID, SPEC, fileLabels, versionLabels)
 
     const apiKinds = documentAndOperationsApiKind(result)
     expect(apiKinds).toHaveLength(3) // document + 2 operations

--- a/test/graphql-build-apikind.test.ts
+++ b/test/graphql-build-apikind.test.ts
@@ -16,7 +16,6 @@
 
 import {
   APIHUB_API_COMPATIBILITY_KIND_BWC,
-  APIHUB_API_COMPATIBILITY_KIND_EXPERIMENTAL,
   APIHUB_API_COMPATIBILITY_KIND_NO_BWC,
   ApihubApiCompatibilityKind,
   BuildResult,
@@ -26,11 +25,18 @@ import { buildPackageFromContent } from './helpers'
 
 const BWC = APIHUB_API_COMPATIBILITY_KIND_BWC
 const NO_BWC = APIHUB_API_COMPATIBILITY_KIND_NO_BWC
-const EXPERIMENTAL = APIHUB_API_COMPATIBILITY_KIND_EXPERIMENTAL
 
 const FILE_ID = 'spec.gql'
 const SDL = 'type Query {\n  fruits: String\n  vegetables: String\n}' // two operations
 
+// Difference from `apiKinds.test.ts`:
+//   - `apiKinds.test.ts` covers REST and asserts only the DOCUMENT apiKind, exhaustively
+//     exercising the shared `calculateApiKindFromLabels` resolution (uppercase / experimental /
+//     invalid / file-vs-version priority).
+//   - This file covers the GraphQL-specific bit that resolution does NOT: every OPERATION of the
+//     document inherits the document apiKind (`graphql.operation.ts`). It therefore keeps only the
+//     representative label channels (default / file / version) and checks document + all operations,
+//     instead of re-testing the shared resolver.
 describe('GraphQL build api-kind', () => {
   // Document apiKind + apiKind of every operation — they must all match.
   const documentAndOperationsApiKind = (result: BuildResult): (ApihubApiCompatibilityKind | undefined)[] => {
@@ -42,9 +48,7 @@ describe('GraphQL build api-kind', () => {
   it.each<{ id: string; desc: string; fileLabels?: Labels; versionLabels?: Labels; expected: ApihubApiCompatibilityKind }>([
     { id: 'default', desc: 'no labels → BWC by default', expected: BWC },
     { id: 'file-nb', desc: 'file label no-BWC', fileLabels: ['apihub/x-api-kind: no-BWC'], expected: NO_BWC },
-    { id: 'file-exp', desc: 'file label experimental', fileLabels: ['apihub/x-api-kind: experimental'], expected: EXPERIMENTAL },
     { id: 'version-nb', desc: 'version label no-BWC', versionLabels: ['apihub/x-api-kind: no-BWC'], expected: NO_BWC },
-    { id: 'invalid', desc: 'invalid label value → BWC', fileLabels: ['apihub/x-api-kind: broken'], expected: BWC },
   ])('should apply $desc to the document and all its operations', async ({ id, fileLabels, versionLabels, expected }) => {
     const result = await buildPackageFromContent(`gql-build-apikind/${id}`, FILE_ID, SDL, fileLabels, versionLabels)
 
@@ -52,17 +56,6 @@ describe('GraphQL build api-kind', () => {
     expect(apiKinds).toHaveLength(3) // document + 2 operations
     for (const apiKind of apiKinds) {
       expect(apiKind).toEqual(expected)
-    }
-  })
-
-  it('should let the file label override the version label', async () => {
-    const result = await buildPackageFromContent(
-      'gql-build-apikind/file-over-version', FILE_ID, SDL,
-      ['apihub/x-api-kind: no-BWC'], ['apihub/x-api-kind: BWC'],
-    )
-
-    for (const apiKind of documentAndOperationsApiKind(result)) {
-      expect(apiKind).toEqual(NO_BWC)
     }
   })
 })

--- a/test/graphql-build-apikind.test.ts
+++ b/test/graphql-build-apikind.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  APIHUB_API_COMPATIBILITY_KIND_BWC,
+  APIHUB_API_COMPATIBILITY_KIND_EXPERIMENTAL,
+  APIHUB_API_COMPATIBILITY_KIND_NO_BWC,
+  ApihubApiCompatibilityKind,
+  BuildResult,
+  Labels,
+} from '../src'
+import { buildPackageFromContent } from './helpers'
+
+const BWC = APIHUB_API_COMPATIBILITY_KIND_BWC
+const NO_BWC = APIHUB_API_COMPATIBILITY_KIND_NO_BWC
+const EXPERIMENTAL = APIHUB_API_COMPATIBILITY_KIND_EXPERIMENTAL
+
+const FILE_ID = 'spec.gql'
+const SDL = 'type Query {\n  fruits: String\n  vegetables: String\n}' // two operations
+
+describe('GraphQL build api-kind', () => {
+  // Document apiKind + apiKind of every operation — they must all match.
+  const documentAndOperationsApiKind = (result: BuildResult): (ApihubApiCompatibilityKind | undefined)[] => {
+    const document = result.documents.get(FILE_ID)
+    const operations = Array.from(result.operations.values())
+    return [document?.apiKind, ...operations.map(operation => operation.apiKind)]
+  }
+
+  it.each<{ id: string; desc: string; fileLabels?: Labels; versionLabels?: Labels; expected: ApihubApiCompatibilityKind }>([
+    { id: 'default', desc: 'no labels → BWC by default', expected: BWC },
+    { id: 'file-nb', desc: 'file label no-BWC', fileLabels: ['apihub/x-api-kind: no-BWC'], expected: NO_BWC },
+    { id: 'file-exp', desc: 'file label experimental', fileLabels: ['apihub/x-api-kind: experimental'], expected: EXPERIMENTAL },
+    { id: 'version-nb', desc: 'version label no-BWC', versionLabels: ['apihub/x-api-kind: no-BWC'], expected: NO_BWC },
+    { id: 'invalid', desc: 'invalid label value → BWC', fileLabels: ['apihub/x-api-kind: broken'], expected: BWC },
+  ])('should apply $desc to the document and all its operations', async ({ id, fileLabels, versionLabels, expected }) => {
+    const result = await buildPackageFromContent(`gql-build-apikind/${id}`, FILE_ID, SDL, fileLabels, versionLabels)
+
+    const apiKinds = documentAndOperationsApiKind(result)
+    expect(apiKinds).toHaveLength(3) // document + 2 operations
+    for (const apiKind of apiKinds) {
+      expect(apiKind).toEqual(expected)
+    }
+  })
+
+  it('should let the file label override the version label', async () => {
+    const result = await buildPackageFromContent(
+      'gql-build-apikind/file-over-version', FILE_ID, SDL,
+      ['apihub/x-api-kind: no-BWC'], ['apihub/x-api-kind: BWC'],
+    )
+
+    for (const apiKind of documentAndOperationsApiKind(result)) {
+      expect(apiKind).toEqual(NO_BWC)
+    }
+  })
+})

--- a/test/graphql-changelog-apikind.test.ts
+++ b/test/graphql-changelog-apikind.test.ts
@@ -218,29 +218,18 @@ describe('GraphQL changelog api-kind (e2e)', () => {
     return editor.run()
   }
 
-  // Full (prev, curr) matrix over {BWC, no-BWC, experimental}. ER is hardcoded per row.
+  // Representative cases only — the exhaustive (prev, curr) × {BWC, no-BWC, experimental}
+  // classification is covered by the unit block above. Here e2e just proves the scope function is
+  // wired into graphql.changes and api-diff applies it. ER is hardcoded and guard-checked per row.
   const modifyCases: [ApihubApiCompatibilityKind, ApihubApiCompatibilityKind, ChangeType][] = [
     [BWC, BWC, BREAKING_CHANGE_TYPE],
     [BWC, NO_BWC, RISKY_CHANGE_TYPE],
-    [BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
     [NO_BWC, BWC, RISKY_CHANGE_TYPE], // either side no-bwc → risky
-    [NO_BWC, NO_BWC, RISKY_CHANGE_TYPE],
-    [NO_BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
-    [EXPERIMENTAL, BWC, RISKY_CHANGE_TYPE], // either side no-bwc → risky
-    [EXPERIMENTAL, NO_BWC, RISKY_CHANGE_TYPE],
-    [EXPERIMENTAL, EXPERIMENTAL, RISKY_CHANGE_TYPE],
   ]
 
   const removeCases: [ApihubApiCompatibilityKind, ApihubApiCompatibilityKind, ChangeType][] = [
     [BWC, BWC, BREAKING_CHANGE_TYPE],
-    [BWC, NO_BWC, BREAKING_CHANGE_TYPE],
-    [BWC, EXPERIMENTAL, BREAKING_CHANGE_TYPE],
-    [NO_BWC, BWC, RISKY_CHANGE_TYPE],
-    [NO_BWC, NO_BWC, RISKY_CHANGE_TYPE],
-    [NO_BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
-    [EXPERIMENTAL, BWC, RISKY_CHANGE_TYPE],
-    [EXPERIMENTAL, NO_BWC, RISKY_CHANGE_TYPE],
-    [EXPERIMENTAL, EXPERIMENTAL, RISKY_CHANGE_TYPE],
+    [NO_BWC, BWC, RISKY_CHANGE_TYPE], // removal keyed on previous
   ]
 
   describe('Modification (either side)', () => {
@@ -281,25 +270,11 @@ describe('GraphQL changelog api-kind (e2e)', () => {
       expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
     })
 
-    test('should classify modification as risky when only the previous version label is no-BWC', async () => {
-      const result = await buildGqlChangelogApiKind(
-        'gql-apikind-modify-vlabel/prev-nb', MODIFY_BEFORE, MODIFY_AFTER, { prevVersionLabels: NB },
-      )
-      expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
-    })
-
     test('should classify removal as risky when the previous version label is no-BWC', async () => {
       const result = await buildGqlChangelogApiKind(
         'gql-apikind-remove-vlabel/prev-nb', REMOVE_BEFORE, REMOVE_AFTER, { prevVersionLabels: NB },
       )
       expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
-    })
-
-    test('should classify removal as breaking when only the current version label is no-BWC', async () => {
-      const result = await buildGqlChangelogApiKind(
-        'gql-apikind-remove-vlabel/curr-nb', REMOVE_BEFORE, REMOVE_AFTER, { currVersionLabels: NB },
-      )
-      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
     })
   })
 })

--- a/test/graphql-changelog-apikind.test.ts
+++ b/test/graphql-changelog-apikind.test.ts
@@ -47,28 +47,28 @@ describe('GraphQL api-compatibility scope function', () => {
   const OP = ['queries', 'q1']
   const OBJ = {} // "exists"
 
-  describe('Root scope (document-level, keyed on current)', () => {
+  describe('Root scope (document-level, either side)', () => {
     it.each([
       // prev    | curr    | expected
       [BWC, BWC, BACKWARD_COMPATIBLE],
       [BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
-      [NO_BWC, BWC, BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, NOT_BACKWARD_COMPATIBLE], // either side no-bwc → risky
       [NO_BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
       [BWC, EXPERIMENTAL, NOT_BACKWARD_COMPATIBLE],
-      [EXPERIMENTAL, BWC, BACKWARD_COMPATIBLE],
+      [EXPERIMENTAL, BWC, NOT_BACKWARD_COMPATIBLE],
     ] as const)('should classify root scope prev(%s) curr(%s) as %s', (prev, curr, expected) => {
       expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)([], OBJ, OBJ)).toBe(expected)
     })
   })
 
-  describe('Operation scope — modification (both sides present, keyed on current)', () => {
+  describe('Operation scope — modification (both sides present, either side)', () => {
     it.each([
       [BWC, BWC, BACKWARD_COMPATIBLE],
       [BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
-      [NO_BWC, BWC, BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, NOT_BACKWARD_COMPATIBLE], // either side no-bwc → risky
       [NO_BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
       [NO_BWC, EXPERIMENTAL, NOT_BACKWARD_COMPATIBLE],
-      [EXPERIMENTAL, BWC, BACKWARD_COMPATIBLE],
+      [EXPERIMENTAL, BWC, NOT_BACKWARD_COMPATIBLE],
     ] as const)('should classify operation modification prev(%s) curr(%s) as %s', (prev, curr, expected) => {
       expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)(OP, OBJ, OBJ)).toBe(expected)
     })
@@ -86,12 +86,12 @@ describe('GraphQL api-compatibility scope function', () => {
     })
   })
 
-  describe('Operation scope — addition (after only, keyed on current)', () => {
+  describe('Operation scope — addition (after only, either side)', () => {
     it.each([
+      [BWC, BWC, BACKWARD_COMPATIBLE],
       [BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
-      [NO_BWC, BWC, BACKWARD_COMPATIBLE],
-      [BWC, EXPERIMENTAL, NOT_BACKWARD_COMPATIBLE],
-      [EXPERIMENTAL, BWC, BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, NOT_BACKWARD_COMPATIBLE], // either side no-bwc → risky
+      [EXPERIMENTAL, BWC, NOT_BACKWARD_COMPATIBLE],
     ] as const)('should classify operation addition prev(%s) curr(%s) as %s', (prev, curr, expected) => {
       expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)(OP, undefined, OBJ)).toBe(expected)
     })
@@ -105,9 +105,9 @@ describe('GraphQL api-compatibility scope function', () => {
     it.each([
       ['mutations', 'm1'],
       ['subscriptions', 's1'],
-    ] as const)('should classify %s modification by current', (segment, name) => {
+    ] as const)('should classify %s modification by either side', (segment, name) => {
       const fn = createGraphqlApiCompatibilityScopeFunction(NO_BWC, BWC)
-      expect(fn([segment, name], OBJ, OBJ)).toBe(BACKWARD_COMPATIBLE) // deviation
+      expect(fn([segment, name], OBJ, OBJ)).toBe(NOT_BACKWARD_COMPATIBLE) // either side no-bwc → risky
     })
   })
 
@@ -160,8 +160,9 @@ describe('GraphQL changelog api-kind (e2e)', () => {
     [EXPERIMENTAL]: 'apihub/x-api-kind: experimental',
   }
 
-  function expectedModifyType(currDoc: ApihubApiCompatibilityKind): ChangeType {
-    return isNoBwcLike(currDoc) ? RISKY_CHANGE_TYPE : BREAKING_CHANGE_TYPE
+  // Modification: risky if EITHER the previous or the current document api-kind is no-bwc-like.
+  function expectedModifyType(prevDoc: ApihubApiCompatibilityKind, currDoc: ApihubApiCompatibilityKind): ChangeType {
+    return (isNoBwcLike(prevDoc) || isNoBwcLike(currDoc)) ? RISKY_CHANGE_TYPE : BREAKING_CHANGE_TYPE
   }
 
   function expectedRemoveType(prevDoc: ApihubApiCompatibilityKind): ChangeType {
@@ -222,10 +223,10 @@ describe('GraphQL changelog api-kind (e2e)', () => {
     [BWC, BWC, BREAKING_CHANGE_TYPE],
     [BWC, NO_BWC, RISKY_CHANGE_TYPE],
     [BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
-    [NO_BWC, BWC, BREAKING_CHANGE_TYPE],
+    [NO_BWC, BWC, RISKY_CHANGE_TYPE], // either side no-bwc → risky
     [NO_BWC, NO_BWC, RISKY_CHANGE_TYPE],
     [NO_BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
-    [EXPERIMENTAL, BWC, BREAKING_CHANGE_TYPE],
+    [EXPERIMENTAL, BWC, RISKY_CHANGE_TYPE], // either side no-bwc → risky
     [EXPERIMENTAL, NO_BWC, RISKY_CHANGE_TYPE],
     [EXPERIMENTAL, EXPERIMENTAL, RISKY_CHANGE_TYPE],
   ]
@@ -242,10 +243,10 @@ describe('GraphQL changelog api-kind (e2e)', () => {
     [EXPERIMENTAL, EXPERIMENTAL, RISKY_CHANGE_TYPE],
   ]
 
-  describe('Modification (keyed on current)', () => {
+  describe('Modification (either side)', () => {
     test.each(modifyCases)('should classify modification prev(%s) curr(%s) as %s', async (prev, curr, expectedType) => {
       // Guard: hardcoded ER must match the reference rule.
-      expect(expectedType).toBe(expectedModifyType(curr))
+      expect(expectedType).toBe(expectedModifyType(prev, curr))
 
       const result = await buildGqlChangelogApiKind(
         `gql-apikind-modify/${prev}--${curr}`, MODIFY_BEFORE, MODIFY_AFTER,
@@ -280,11 +281,11 @@ describe('GraphQL changelog api-kind (e2e)', () => {
       expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
     })
 
-    test('should classify modification as breaking when only the previous version label is no-BWC (deviation)', async () => {
+    test('should classify modification as risky when only the previous version label is no-BWC', async () => {
       const result = await buildGqlChangelogApiKind(
         'gql-apikind-modify-vlabel/prev-nb', MODIFY_BEFORE, MODIFY_AFTER, { prevVersionLabels: NB },
       )
-      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+      expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
     })
 
     test('should classify removal as risky when the previous version label is no-BWC', async () => {

--- a/test/graphql-changelog-apikind.test.ts
+++ b/test/graphql-changelog-apikind.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  APIHUB_API_COMPATIBILITY_KIND_BWC,
+  APIHUB_API_COMPATIBILITY_KIND_EXPERIMENTAL,
+  APIHUB_API_COMPATIBILITY_KIND_NO_BWC,
+  ApihubApiCompatibilityKind,
+  BREAKING_CHANGE_TYPE,
+  BUILD_TYPE,
+  BuildResult,
+  GRAPHQL_API_TYPE,
+  isNoBwcLike,
+  Labels,
+  RISKY_CHANGE_TYPE,
+  VERSION_STATUS,
+} from '../src'
+import { createGraphqlApiCompatibilityScopeFunction } from '../src/components/compare/graphql.bwc.validation'
+import {
+  API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE,
+  API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE,
+} from '@netcracker/qubership-apihub-api-diff'
+import { changesSummaryMatcher, Editor, LocalRegistry } from './helpers'
+import { takeIfDefined } from '../src/utils'
+
+const BWC = APIHUB_API_COMPATIBILITY_KIND_BWC
+const NO_BWC = APIHUB_API_COMPATIBILITY_KIND_NO_BWC
+const EXPERIMENTAL = APIHUB_API_COMPATIBILITY_KIND_EXPERIMENTAL
+
+const BACKWARD_COMPATIBLE = API_COMPATIBILITY_KIND_BACKWARD_COMPATIBLE
+const NOT_BACKWARD_COMPATIBLE = API_COMPATIBILITY_KIND_NOT_BACKWARD_COMPATIBLE
+
+describe('GraphQL api-compatibility scope function', () => {
+  const OP = ['queries', 'q1']
+  const OBJ = {} // "exists"
+
+  describe('Root scope (document-level, keyed on current)', () => {
+    it.each([
+      // prev    | curr    | expected
+      [BWC, BWC, BACKWARD_COMPATIBLE],
+      [BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, BACKWARD_COMPATIBLE],
+      [NO_BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
+      [BWC, EXPERIMENTAL, NOT_BACKWARD_COMPATIBLE],
+      [EXPERIMENTAL, BWC, BACKWARD_COMPATIBLE],
+    ] as const)('should classify root scope prev(%s) curr(%s) as %s', (prev, curr, expected) => {
+      expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)([], OBJ, OBJ)).toBe(expected)
+    })
+  })
+
+  describe('Operation scope — modification (both sides present, keyed on current)', () => {
+    it.each([
+      [BWC, BWC, BACKWARD_COMPATIBLE],
+      [BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, BACKWARD_COMPATIBLE],
+      [NO_BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
+      [NO_BWC, EXPERIMENTAL, NOT_BACKWARD_COMPATIBLE],
+      [EXPERIMENTAL, BWC, BACKWARD_COMPATIBLE],
+    ] as const)('should classify operation modification prev(%s) curr(%s) as %s', (prev, curr, expected) => {
+      expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)(OP, OBJ, OBJ)).toBe(expected)
+    })
+  })
+
+  describe('Operation scope — removal (before only, keyed on previous)', () => {
+    it.each([
+      [BWC, BWC, BACKWARD_COMPATIBLE],
+      [BWC, NO_BWC, BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, NOT_BACKWARD_COMPATIBLE],
+      [NO_BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
+      [EXPERIMENTAL, BWC, NOT_BACKWARD_COMPATIBLE],
+    ] as const)('should classify operation removal prev(%s) curr(%s) as %s', (prev, curr, expected) => {
+      expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)(OP, OBJ, undefined)).toBe(expected)
+    })
+  })
+
+  describe('Operation scope — addition (after only, keyed on current)', () => {
+    it.each([
+      [BWC, NO_BWC, NOT_BACKWARD_COMPATIBLE],
+      [NO_BWC, BWC, BACKWARD_COMPATIBLE],
+      [BWC, EXPERIMENTAL, NOT_BACKWARD_COMPATIBLE],
+      [EXPERIMENTAL, BWC, BACKWARD_COMPATIBLE],
+    ] as const)('should classify operation addition prev(%s) curr(%s) as %s', (prev, curr, expected) => {
+      expect(createGraphqlApiCompatibilityScopeFunction(prev, curr)(OP, undefined, OBJ)).toBe(expected)
+    })
+  })
+
+  // The blocks above exercise the classification rules on `queries`. GraphQL has two more
+  // operation root types — `mutations` and `subscriptions` — which the scope function recognises
+  // by their root path segment and must treat identically. Here we only assert that same behaviour;
+  // the classification rules themselves are already covered via `queries` above.
+  describe('Mutations and subscriptions behave like queries', () => {
+    it.each([
+      ['mutations', 'm1'],
+      ['subscriptions', 's1'],
+    ] as const)('should classify %s modification by current', (segment, name) => {
+      const fn = createGraphqlApiCompatibilityScopeFunction(NO_BWC, BWC)
+      expect(fn([segment, name], OBJ, OBJ)).toBe(BACKWARD_COMPATIBLE) // deviation
+    })
+  })
+
+  describe('experimental produces the same result as no-BWC', () => {
+    const replace = (apihubApiCompatibilityKind: typeof BWC | typeof NO_BWC): typeof BWC | typeof EXPERIMENTAL =>
+      (apihubApiCompatibilityKind === NO_BWC ? EXPERIMENTAL : apihubApiCompatibilityKind)
+    const docs = [BWC, NO_BWC] as const
+    const beforeAfter: [unknown, unknown][] = [[OBJ, OBJ], [OBJ, undefined], [undefined, OBJ]]
+
+    it.each(docs)('should produce the same root scope result as no-BWC (document=%s)', (prev) => {
+      for (const curr of docs) {
+        const noBwc = createGraphqlApiCompatibilityScopeFunction(prev, curr)([], OBJ, OBJ)
+        const exp = createGraphqlApiCompatibilityScopeFunction(replace(prev), replace(curr))([], OBJ, OBJ)
+        expect(exp).toBe(noBwc)
+      }
+    })
+
+    it.each(docs)('should produce the same operation scope result as no-BWC (document=%s)', (prev) => {
+      for (const curr of docs) {
+        for (const [before, after] of beforeAfter) {
+          const noBwc = createGraphqlApiCompatibilityScopeFunction(prev, curr)(OP, before, after)
+          const exp = createGraphqlApiCompatibilityScopeFunction(replace(prev), replace(curr))(OP, before, after)
+          expect(exp).toBe(noBwc)
+        }
+      }
+    })
+  })
+
+  describe('paths outside the classification scope return undefined', () => {
+    const fn = createGraphqlApiCompatibilityScopeFunction(NO_BWC, NO_BWC)
+
+    it('should return undefined when the operation is absent on both sides', () => {
+      expect(fn(OP, undefined, undefined)).toBeUndefined()
+    })
+    it('should return undefined for a non-operation top-level segment', () => {
+      expect(fn(['components', 'Foo'], OBJ, OBJ)).toBeUndefined()
+    })
+    it('should return undefined for a deeper-than-operation path', () => {
+      expect(fn(['queries', 'q1', 'args'], OBJ, OBJ)).toBeUndefined()
+    })
+  })
+})
+
+describe('GraphQL changelog api-kind (e2e)', () => {
+  type ChangeType = typeof BREAKING_CHANGE_TYPE | typeof RISKY_CHANGE_TYPE
+
+  const LABEL: Record<ApihubApiCompatibilityKind, string> = {
+    [BWC]: 'apihub/x-api-kind: BWC',
+    [NO_BWC]: 'apihub/x-api-kind: no-BWC',
+    [EXPERIMENTAL]: 'apihub/x-api-kind: experimental',
+  }
+
+  function expectedModifyType(currDoc: ApihubApiCompatibilityKind): ChangeType {
+    return isNoBwcLike(currDoc) ? RISKY_CHANGE_TYPE : BREAKING_CHANGE_TYPE
+  }
+
+  function expectedRemoveType(prevDoc: ApihubApiCompatibilityKind): ChangeType {
+    return isNoBwcLike(prevDoc) ? RISKY_CHANGE_TYPE : BREAKING_CHANGE_TYPE
+  }
+
+  const MODIFY_BEFORE = 'type Query {\n  fruits: String\n}'
+  const MODIFY_AFTER = 'type Query {\n  fruits: Int\n}' // breaking: field type change
+  const REMOVE_BEFORE = 'type Query {\n  fruits: String\n  fruitsByColor: String\n}'
+  const REMOVE_AFTER = 'type Query {\n  fruits: String\n}' // breaking: operation removed
+
+  async function buildGqlChangelogApiKind(
+    packageId: string,
+    beforeSdl: string,
+    afterSdl: string,
+    labels: {
+      prevFileLabels?: Labels
+      currFileLabels?: Labels
+      prevVersionLabels?: Labels
+      currVersionLabels?: Labels
+    } = {},
+  ): Promise<BuildResult> {
+    const portal = new LocalRegistry(packageId)
+
+    await portal.publishFromContent(
+      { 'before.gql': beforeSdl },
+      {
+        packageId,
+        version: 'v1',
+        metadata: { ...takeIfDefined({ versionLabels: labels.prevVersionLabels }) },
+        files: [{ fileId: 'before.gql', publish: true, ...takeIfDefined({ labels: labels.prevFileLabels }) }],
+      },
+    )
+    await portal.publishFromContent(
+      { 'after.gql': afterSdl },
+      {
+        packageId,
+        version: 'v2',
+        metadata: { ...takeIfDefined({ versionLabels: labels.currVersionLabels }) },
+        files: [{ fileId: 'after.gql', ...takeIfDefined({ labels: labels.currFileLabels }) }],
+      },
+    )
+
+    const editor = new Editor(packageId, {
+      packageId,
+      version: 'v2',
+      previousVersionPackageId: packageId,
+      previousVersion: 'v1',
+      status: VERSION_STATUS.RELEASE,
+      buildType: BUILD_TYPE.CHANGELOG,
+    }, {}, portal)
+
+    return editor.run()
+  }
+
+  // Full (prev, curr) matrix over {BWC, no-BWC, experimental}. ER is hardcoded per row.
+  const modifyCases: [ApihubApiCompatibilityKind, ApihubApiCompatibilityKind, ChangeType][] = [
+    [BWC, BWC, BREAKING_CHANGE_TYPE],
+    [BWC, NO_BWC, RISKY_CHANGE_TYPE],
+    [BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
+    [NO_BWC, BWC, BREAKING_CHANGE_TYPE],
+    [NO_BWC, NO_BWC, RISKY_CHANGE_TYPE],
+    [NO_BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
+    [EXPERIMENTAL, BWC, BREAKING_CHANGE_TYPE],
+    [EXPERIMENTAL, NO_BWC, RISKY_CHANGE_TYPE],
+    [EXPERIMENTAL, EXPERIMENTAL, RISKY_CHANGE_TYPE],
+  ]
+
+  const removeCases: [ApihubApiCompatibilityKind, ApihubApiCompatibilityKind, ChangeType][] = [
+    [BWC, BWC, BREAKING_CHANGE_TYPE],
+    [BWC, NO_BWC, BREAKING_CHANGE_TYPE],
+    [BWC, EXPERIMENTAL, BREAKING_CHANGE_TYPE],
+    [NO_BWC, BWC, RISKY_CHANGE_TYPE],
+    [NO_BWC, NO_BWC, RISKY_CHANGE_TYPE],
+    [NO_BWC, EXPERIMENTAL, RISKY_CHANGE_TYPE],
+    [EXPERIMENTAL, BWC, RISKY_CHANGE_TYPE],
+    [EXPERIMENTAL, NO_BWC, RISKY_CHANGE_TYPE],
+    [EXPERIMENTAL, EXPERIMENTAL, RISKY_CHANGE_TYPE],
+  ]
+
+  describe('Modification (keyed on current)', () => {
+    test.each(modifyCases)('should classify modification prev(%s) curr(%s) as %s', async (prev, curr, expectedType) => {
+      // Guard: hardcoded ER must match the reference rule.
+      expect(expectedType).toBe(expectedModifyType(curr))
+
+      const result = await buildGqlChangelogApiKind(
+        `gql-apikind-modify/${prev}--${curr}`, MODIFY_BEFORE, MODIFY_AFTER,
+        { prevFileLabels: [LABEL[prev]], currFileLabels: [LABEL[curr]] },
+      )
+      expect(result).toEqual(changesSummaryMatcher({ [expectedType]: 1 }, GRAPHQL_API_TYPE))
+    })
+  })
+
+  describe('Removal (keyed on previous)', () => {
+    test.each(removeCases)('should classify removal prev(%s) curr(%s) as %s', async (prev, curr, expectedType) => {
+      // Guard: hardcoded ER must match the reference rule.
+      expect(expectedType).toBe(expectedRemoveType(prev))
+
+      const result = await buildGqlChangelogApiKind(
+        `gql-apikind-remove/${prev}--${curr}`, REMOVE_BEFORE, REMOVE_AFTER,
+        { prevFileLabels: [LABEL[prev]], currFileLabels: [LABEL[curr]] },
+      )
+      expect(result).toEqual(changesSummaryMatcher({ [expectedType]: 1 }, GRAPHQL_API_TYPE))
+    })
+  })
+
+  // Version labels are the k8s-service-label channel: at publish they are baked into the stored
+  // document apiKind, so changelog resolves them via currDoc/prevDoc.apiKind (same as file labels).
+  describe('Version-label channel', () => {
+    const NB: Labels = ['apihub/x-api-kind: no-BWC']
+
+    test('should classify modification as risky when the current version label is no-BWC', async () => {
+      const result = await buildGqlChangelogApiKind(
+        'gql-apikind-modify-vlabel/curr-nb', MODIFY_BEFORE, MODIFY_AFTER, { currVersionLabels: NB },
+      )
+      expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+    })
+
+    test('should classify modification as breaking when only the previous version label is no-BWC (deviation)', async () => {
+      const result = await buildGqlChangelogApiKind(
+        'gql-apikind-modify-vlabel/prev-nb', MODIFY_BEFORE, MODIFY_AFTER, { prevVersionLabels: NB },
+      )
+      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+    })
+
+    test('should classify removal as risky when the previous version label is no-BWC', async () => {
+      const result = await buildGqlChangelogApiKind(
+        'gql-apikind-remove-vlabel/prev-nb', REMOVE_BEFORE, REMOVE_AFTER, { prevVersionLabels: NB },
+      )
+      expect(result).toEqual(changesSummaryMatcher({ [RISKY_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+    })
+
+    test('should classify removal as breaking when only the current version label is no-BWC', async () => {
+      const result = await buildGqlChangelogApiKind(
+        'gql-apikind-remove-vlabel/curr-nb', REMOVE_BEFORE, REMOVE_AFTER, { currVersionLabels: NB },
+      )
+      expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+    })
+  })
+})

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -315,6 +315,25 @@ export async function buildPackageWithDefaultConfig(
   return editor.run()
 }
 
+export async function buildPackageFromContent(
+  packageId: string,
+  fileId: string,
+  content: string,
+  fileLabels?: Labels,
+  versionLabels?: Labels,
+): Promise<BuildResult> {
+  const portal = new LocalRegistry(packageId)
+  return portal.publishFromContent(
+    { [fileId]: content },
+    {
+      packageId,
+      version: 'v1',
+      metadata: { ...takeIfDefined({ versionLabels: versionLabels }) },
+      files: [{ fileId, publish: true, ...takeIfDefined({ labels: fileLabels }) }],
+    },
+  )
+}
+
 export async function buildChangelogPackageDefaultConfig(
   packageId: string,
   filesBefore: BuildConfigFile[] = [{ fileId: 'before.yaml', publish: true }],


### PR DESCRIPTION
# Support no-BWC / experimental apiKind for GraphQL API Changes

## Summary
Adds document-level backward-compatibility classification for GraphQL, so that
breaking changes in documents marked `no-BWC` (or `experimental`) are reclassified
as **semi-breaking / Requires Attention** (risky) instead of hard breaking. This
brings GraphQL in line with the existing REST and AsyncAPI behaviour.

GraphQL apiKind is **document-level only** (all operations of a document inherit it;
there is no per-operation `x-api-kind` in the SDL). The build side already resolved
`document.apiKind` from labels — the missing piece was applying it during changelog
comparison. This PR fills that gap.

## Classification (document apiKind, inherited by all operations)
| Change | prev/curr apiKind | Severity |
|---|---|---|
| Breaking modification | either side `no-BWC`/`experimental` | risky (Requires Attention) |
| Breaking modification | both `BWC` | breaking |
| Operation removed | previous `no-BWC`/`experimental` | risky |
| Operation removed | previous `BWC` | breaking |
| Non-breaking change | any | non-breaking |

