### PR TITLE
fix: omit tags not used by any REST operation when exporting operation group

### DIFF
--- a/src/strategies/document-group.strategy.ts
+++ b/src/strategies/document-group.strategy.ts
@@ -28,6 +28,7 @@ import {
 import {
   calculateRestOperationId,
   EXPORT_API_TYPE_FORMATS,
+  filterUsedTags,
   fromBase64,
   isValidHttpMethod,
   normalizeGraphQL,
@@ -192,6 +193,9 @@ function transformDocumentData(versionDocument: VersionDocument): OpenAPIV3.Docu
     paths: {},
   }
 
+  // Tag names used by the group's operations (from normalized ops → $ref-safe).
+  const usedTagNames = new Set<string>()
+
   for (const path of Object.keys(normalizedPaths)) {
     const sourcePathItem = sourcePaths[path]
     const normalizedPathItem = normalizedPaths[path]
@@ -221,6 +225,8 @@ function transformDocumentData(versionDocument: VersionDocument): OpenAPIV3.Docu
       }
 
       if (versionDocument.operationIds.includes(operationId)) {
+        methodData?.tags?.forEach((tag) => usedTagNames.add(tag))
+
         const pathData = sourceDocument.paths[path]!
         const isRefPathData = !!pathData.$ref
         resultDocument.paths[path] = isRefPathData
@@ -236,6 +242,12 @@ function transformDocumentData(versionDocument: VersionDocument): OpenAPIV3.Docu
         }
       }
     }
+  }
+
+  // Keep only tags referenced by the group's operations.
+  resultDocument.tags = filterUsedTags(resultDocument.tags, usedTagNames)
+  if (!resultDocument.tags) {
+    delete resultDocument.tags
   }
 
   return resultDocument

--- a/src/utils/mergeOpenapiDocuments.ts
+++ b/src/utils/mergeOpenapiDocuments.ts
@@ -133,19 +133,24 @@ const validateResult = (rules: DiffRule[], diffs: Diff[], title1: string, title2
   }
 }
 
+export function filterUsedTags<T extends { name: string }>(
+  tags: readonly T[] | undefined,
+  usedTagNames: ReadonlySet<string>,
+): T[] | undefined {
+  const usedTags = tags?.filter(({ name }) => usedTagNames.has(name))
+  return usedTags && usedTags.length ? usedTags : undefined
+}
+
 export function getUsedTags(specs: OpenAPIV3.Document[]): OpenAPIV3.TagObject[] | undefined {
   const tagsWithUsages = specs
     .map(({ tags, paths }) => {
-      const specTags: string[] = []
+      const specTags = new Set<string>()
       for (const path in paths) {
         for (const operation in paths[path]) {
-          const tags = paths[path]?.[operation as OpenAPIV3.HttpMethods]?.tags
-          if (tags) {
-            specTags.push(...tags)
-          }
+          paths[path]?.[operation as OpenAPIV3.HttpMethods]?.tags?.forEach((tag) => specTags.add(tag))
         }
       }
-      return tags?.filter(({ name }) => specTags.includes(name))
+      return filterUsedTags(tags, specTags)
     })
     .filter((tags): tags is OpenAPIV3.TagObject[] => tags !== undefined)
     .flat()

--- a/test/document-group.test.ts
+++ b/test/document-group.test.ts
@@ -17,6 +17,7 @@
 import { loadYaml } from '@netcracker/qubership-apihub-api-unifier'
 import {
   BUILD_TYPE,
+  BuildConfig,
   BuildConfigAggregator,
   BuildResult,
   FILE_FORMAT_GRAPHQL,
@@ -84,6 +85,21 @@ const BASE_OPERATION_PATH = 'path-operations'
 const PATH_ITEMS_OPERATION_PATH = 'pathitems-operations'
 type DOCUMENT_GROUP_PATHS = typeof BASE_OPERATION_PATH | typeof PATH_ITEMS_OPERATION_PATH
 
+async function runReducedFromContent(packageId: string, spec: string, operationIds: string[]): Promise<BuildResult> {
+  const pkg = LocalRegistry.openPackage(packageId, { [GROUP_NAME]: operationIds })
+  await pkg.publishFromContent(
+    { '1.yaml': spec },
+    { packageId, version: 'v1', files: [{ fileId: '1.yaml', publish: true }] },
+  )
+  const editor = new Editor(packageId, { packageId, version: 'v1' } as BuildConfig, {}, pkg)
+  return editor.run({
+    packageId,
+    buildType: BUILD_TYPE.REDUCED_SOURCE_SPECIFICATIONS,
+    groupName: GROUP_NAME,
+    apiType: REST_API_TYPE,
+  })
+}
+
 describe('Document Group test', () => {
   describe('Base path operations', () => {
     runCommonTests(BASE_OPERATION_PATH)
@@ -98,6 +114,39 @@ describe('Document Group test', () => {
 
     test('should have properly merged documents', async () => {
       await runMergeOperationsCase('basic-documents-for-merge')
+    })
+
+    test('should exclude tags that have no operation in the group', async () => {
+      const spec = `
+      openapi: "3.0.0"
+      info: { title: test, version: 0.1.0 }
+      paths:
+        /path1: { get: { tags: [Alpha], responses: { '200': { description: OK } } } }
+        /path2: { get: { tags: [Beta], responses: { '200': { description: OK } } } }
+      tags:
+        - { name: Alpha, description: alpha tag }
+        - { name: Beta, description: beta tag }
+      `
+      const result = await runReducedFromContent('tags-no-operation', spec, ['path1-get'])
+
+      const [document] = Array.from(result.documents.values())
+      expect(document.data.tags).toEqual([{ name: 'Alpha', description: 'alpha tag' }])
+    })
+
+    test('should drop all tags when the operation references an undeclared tag', async () => {
+      const spec = `
+      openapi: "3.0.0"
+      info: { title: test, version: 0.1.0 }
+      paths:
+        /path1: { get: { tags: [Unknown], responses: { '200': { description: OK } } } }
+      tags:
+        - { name: Alpha, description: alpha tag }
+        - { name: Beta, description: beta tag }
+      `
+      const result = await runReducedFromContent('tags-undeclared', spec, ['path1-get'])
+
+      const [document] = Array.from(result.documents.values())
+      expect(document.data).not.toHaveProperty('tags')
     })
 
     test('should have components schema object which is referenced', async () => {
@@ -165,6 +214,27 @@ describe('Document Group test', () => {
 
       test('should have properly merged documents mixed formats (operation + pathItems operation)', async () => {
         await runMergeOperationsCase('documents-pathitems-with-mixed-formats')
+      })
+
+      test('should exclude tags whose operation lives behind a $ref path item', async () => {
+        const spec = `
+        openapi: "3.1.0"
+        info: { title: test, version: 0.1.0 }
+        paths:
+          /path1: { $ref: '#/components/pathItems/pathItem1' }
+          /path2: { $ref: '#/components/pathItems/pathItem2' }
+        tags:
+          - { name: Alpha, description: alpha tag }
+          - { name: Beta, description: beta tag }
+        components:
+          pathItems:
+            pathItem1: { get: { tags: [Alpha], responses: { '200': { description: OK } } } }
+            pathItem2: { get: { tags: [Beta], responses: { '200': { description: OK } } } }
+        `
+        const result = await runReducedFromContent('tags-pathitems', spec, ['path1-get'])
+
+        const [document] = Array.from(result.documents.values())
+        expect(document.data.tags).toEqual([{ name: 'Alpha', description: 'alpha tag' }])
       })
 
       test('should have save pathItems in components', async () => {

--- a/test/document-group.test.ts
+++ b/test/document-group.test.ts
@@ -149,6 +149,42 @@ describe('Document Group test', () => {
       expect(document.data).not.toHaveProperty('tags')
     })
 
+    test('should keep the union of tags when the group has operations with different tags', async () => {
+      const spec = `
+      openapi: "3.0.0"
+      info: { title: test, version: 0.1.0 }
+      paths:
+        /path1: { get: { tags: [Alpha], responses: { '200': { description: OK } } } }
+        /path2: { get: { tags: [Beta], responses: { '200': { description: OK } } } }
+      tags:
+        - { name: Alpha, description: alpha tag }
+        - { name: Beta, description: beta tag }
+      `
+      const result = await runReducedFromContent('tags-union', spec, ['path1-get', 'path2-get'])
+
+      const [document] = Array.from(result.documents.values())
+      expect(document.data.tags).toEqual([
+        { name: 'Alpha', description: 'alpha tag' },
+        { name: 'Beta', description: 'beta tag' },
+      ])
+    })
+
+    test('should drop all tags when the group operation has no tags field', async () => {
+      const spec = `
+      openapi: "3.0.0"
+      info: { title: test, version: 0.1.0 }
+      paths:
+        /path1: { get: { responses: { '200': { description: OK } } } }
+      tags:
+        - { name: Alpha, description: alpha tag }
+        - { name: Beta, description: beta tag }
+      `
+      const result = await runReducedFromContent('tags-no-tags-field', spec, ['path1-get'])
+
+      const [document] = Array.from(result.documents.values())
+      expect(document.data).not.toHaveProperty('tags')
+    })
+
     test('should have components schema object which is referenced', async () => {
       const { result } = await runPublishPackage(
         `document-group/${BASE_OPERATION_PATH}/referenced-json-schema-object`,


### PR DESCRIPTION
# Fix: empty/unused tags in OpenAPI group export

## Problem

When exporting an API group as **Reduced source specifications**, the resulting
OpenAPI document kept root-level `tags` that **no operation in the group uses**.


## Root cause

The two export types map to two builders:

| Export type (UI) | Build type | Path |
|---|---|---|
| Combined specification | `MERGED_SPECIFICATION` | `mergeOpenapiDocuments` → `getUsedTags` (filters tags) |
| Reduced source specifications | `REDUCED_SOURCE_SPECIFICATIONS` | `DocumentGroupStrategy.transformDocumentData` (**no filtering**) |

`transformDocumentData` copied the source root `tags` verbatim (`...restOfSource`)
while rebuilding `paths` to only the group's operations — so unused tag
definitions were never dropped.