### PR TITLE
fix: omit intermediate dashboard comparisons from build result + honor excluded references when flattening dashboard refs

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -685,10 +685,21 @@ export class PackageVersionBuilder implements IPackageVersionBuilder {
       return []
     }
 
-    const referencesCache: BuildConfigRef[] = Object.values(versionReferences.packages ?? {}).filter(pack => !pack.deletedAt).map(pack => ({
-      refId: pack.refId,
-      version: pack.version,
-    }))
+    // A package occurrence is effective when it has at least one non-excluded reference edge.
+    // Conflict-loser occurrences (references[].excluded) must not be emitted, otherwise the same
+    // packageId leaks at two versions and compareVersionsReferences mis-pairs it (last-wins by refId).
+    const includedPackageRefs = new Set(
+      (versionReferences.references ?? [])
+        .filter(reference => !reference.excluded)
+        .map(reference => reference.packageRef),
+    )
+    const referencesCache: BuildConfigRef[] = Object.entries(versionReferences.packages ?? {})
+      .filter(([packageRef, pack]) => !pack.deletedAt && includedPackageRefs.has(packageRef))
+      .map(([, pack]) => ({
+        refId: pack.refId,
+        version: pack.version,
+        kind: pack.kind,
+      }))
     this.referencesCache.set(compositeKey, referencesCache)
 
     return referencesCache

--- a/src/components/compare/compare.ts
+++ b/src/components/compare/compare.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BuildConfigRef, CompareContext, CompareResult, DdlComparison, VersionParams, VersionsComparison } from '../../types'
+import { BuildConfigRef, CompareContext, CompareResult, DdlComparison, KIND_DASHBOARD, VersionParams, VersionsComparison } from '../../types'
 import { compareVersionsOperations } from './compare.operations'
 import { compareVersionsDdl } from './compare.ddl'
 import { getSplittedVersionKey } from '../../utils'
@@ -66,6 +66,14 @@ export async function compareVersionsReferences(
   }
 
   for (const { current, previous } of refsMap.values()) {
+    // Omit intermediate (nested) dashboard pairs: the backend stores a dashboard-pair row only when
+    // that pair is built as a root. Leaf packages under this dashboard are separate entries in the
+    // fully-flattened refsMap, so skipping here drops only the dashboard row, never its leaves. Both
+    // sides describe the same package; `??` covers added-only / removed-only pairs.
+    const kind = current?.kind ?? previous?.kind
+    if (kind === KIND_DASHBOARD) {
+      continue
+    }
     if (previous && current) {
       const comparison = await ctx.versionComparisonResolver(current.version, current.refId, previous.version, previous.refId)
       if (comparison && Array.isArray(comparison.operationTypes)) {

--- a/src/types/external/config.ts
+++ b/src/types/external/config.ts
@@ -25,6 +25,7 @@ import {
 } from '../../consts'
 import { OpenApiExtensionKey } from '@netcracker/qubership-apihub-api-unifier'
 import { ShareabilityStatus } from './documents'
+import type { ReferencedPackageKind } from './references'
 
 export type BuildType = KeyOfConstType<typeof BUILD_TYPE>
 export type VersionStatus = KeyOfConstType<typeof VERSION_STATUS>
@@ -221,4 +222,7 @@ export interface BuildConfigFile {
 export interface BuildConfigRef {
   refId: string
   version: string
+  // Populated by versionReferencesResolver so compareVersionsReferences can omit intermediate
+  // dashboard pairs. Absent on backend-supplied config.refs (which carry only refId/version).
+  kind?: ReferencedPackageKind
 }

--- a/test/dashboards.test.ts
+++ b/test/dashboards.test.ts
@@ -166,3 +166,258 @@ describe('Dashboard build', () => {
     expect((refDdl!.data ?? []).map(change => change.ddlEntityId)).toContain('public-table-widgets')
   }, 100000)
 })
+
+describe('Dashboard changelog omits intermediate dashboard comparisons', () => {
+  // a minimal REST spec whose operation description changes between versions
+  const restSpec = (description: string): string => `openapi: "3.0.0"
+info:
+  title: leaf
+  version: 0.1.0
+paths:
+  /some/path1:
+    get:
+      summary: some operation summary
+      description: ${description}
+      responses:
+        '200':
+          description: some response description
+`
+
+  const publishLeaf = (
+    reg: LocalRegistry,
+    packageId: string,
+    version: string,
+    description: string,
+  ): ReturnType<LocalRegistry['publishFromContent']> =>
+    reg.publishFromContent(
+      { 'spec.yaml': restSpec(description) },
+      { packageId, version, buildType: BUILD_TYPE.BUILD, files: [{ fileId: 'spec.yaml' }] },
+    )
+
+  const publishDdlLeaf = (
+    reg: LocalRegistry,
+    packageId: string,
+    version: string,
+    sql: string,
+  ): ReturnType<LocalRegistry['publishFromContent']> =>
+    reg.publishFromContent(
+      { 'shop.sql': sql },
+      { packageId, version, buildType: BUILD_TYPE.BUILD, files: [{ fileId: 'shop.sql' }] },
+    )
+
+  // a dashboard is a package that declares refs and has no files of its own
+  const publishDashboard = (
+    reg: LocalRegistry,
+    packageId: string,
+    version: string,
+    refs: { refId: string; version: string }[],
+  ): ReturnType<LocalRegistry['publishFromContent']> =>
+    reg.publishFromContent(
+      {},
+      { packageId, version, buildType: BUILD_TYPE.BUILD, refs, files: [] },
+    )
+
+  // identify which package a comparison entry is about: a changed pair has both sides, an added pair
+  // has only the current side (packageId), a removed pair has only the previous side.
+  const packageOf = (comparison: { packageId: string; previousVersionPackageId: string }): string =>
+    comparison.packageId || comparison.previousVersionPackageId
+
+  test('keeps every leaf package (changed/added/removed, any depth), drops all nested dashboards', async () => {
+    const reg = LocalRegistry.openPackage('di/root')
+
+    const rootId = 'di/root'   // main dashboard (built/compared)
+    const midId = 'di/mid'     // intermediate dashboard
+    const innerId = 'di/inner' // intermediate dashboard (nested inside mid)
+    const pkg1 = 'di/pkg1'     // leaf reached only through root → mid → inner (3 dashboard levels), changed
+    const pkg2 = 'di/pkg2'     // leaf under mid, changed
+    const pkg3 = 'di/pkg3'     // leaf added in v2
+    const pkg4 = 'di/pkg4'     // leaf removed in v2
+
+    // leaves first (dashboards aggregate them at build time)
+    await publishLeaf(reg, pkg1, 'v1', 'pkg1 description')
+    await publishLeaf(reg, pkg1, 'v2', 'pkg1 description changed')
+    await publishLeaf(reg, pkg2, 'v1', 'pkg2 description')
+    await publishLeaf(reg, pkg2, 'v2', 'pkg2 description changed')
+    await publishLeaf(reg, pkg3, 'v2', 'pkg3 description') // added leaf → only v2 exists
+    await publishLeaf(reg, pkg4, 'v1', 'pkg4 description') // removed leaf → only v1 exists
+
+    // inner dashboard → pkg1 (disjoint subtree from mid's own leaves)
+    await publishDashboard(reg, innerId, 'v1', [{ refId: pkg1, version: 'v1' }])
+    await publishDashboard(reg, innerId, 'v2', [{ refId: pkg1, version: 'v2' }])
+
+    // mid dashboard → inner + pkg2 (+ pkg4 in v1, + pkg3 in v2). Always has refs in both versions.
+    await publishDashboard(reg, midId, 'v1', [
+      { refId: innerId, version: 'v1' },
+      { refId: pkg2, version: 'v1' },
+      { refId: pkg4, version: 'v1' },
+    ])
+    await publishDashboard(reg, midId, 'v2', [
+      { refId: innerId, version: 'v2' },
+      { refId: pkg2, version: 'v2' },
+      { refId: pkg3, version: 'v2' },
+    ])
+
+    // root dashboard → mid
+    await publishDashboard(reg, rootId, 'v1', [{ refId: midId, version: 'v1' }])
+    await publishDashboard(reg, rootId, 'v2', [{ refId: midId, version: 'v2' }])
+
+    // changelog build of the root dashboard: the resolver flattens the whole tree (CHANGELOG is not
+    // resolvable-locally, so refs are the full descendant set, not just the root's direct children)
+    const editor = new Editor(rootId, {
+      packageId: rootId,
+      version: 'v2',
+      previousVersionPackageId: rootId,
+      previousVersion: 'v1',
+      buildType: BUILD_TYPE.CHANGELOG,
+      status: VERSION_STATUS.RELEASE,
+    }, {}, reg)
+    const result = await editor.run()
+
+    const ids = result.comparisons.map(packageOf)
+
+    // main dashboard is always emitted
+    expect(ids).toContain(rootId)
+    // every changed/added/removed leaf survives, at every depth (pkg1 is 3 dashboard levels deep)
+    expect(ids).toEqual(expect.arrayContaining([pkg1, pkg2, pkg3, pkg4]))
+    // intermediate dashboards are gone
+    expect(ids).not.toContain(midId)
+    expect(ids).not.toContain(innerId)
+    // regression guard: the non-main entries are exactly the leaf set — nothing added or lost
+    const nonMain = ids.filter(id => id !== rootId)
+    expect(new Set(nonMain)).toEqual(new Set([pkg1, pkg2, pkg3, pkg4]))
+  }, 100000)
+
+  // ddl-comparisons.json must stay consistent with comparisons.json: no nested-dashboard rows in
+  // either. A DDL leaf reached only through two dashboard levels must still be emitted. (An intermediate
+  // dashboard never had its OWN DDL entry anyway — compareVersionsDdl looks at own documents only, and a
+  // dashboard has none — so this asserts the DDL leaf survives nested-dashboard flattening and that no
+  // dashboard id leaks into the DDL index, which the shared skip in compareVersionsReferences guarantees.)
+  test('keeps a DDL leaf reached through nested dashboards, with no dashboard rows in ddl-comparisons.json', async () => {
+    const reg = LocalRegistry.openPackage('di-ddl/root')
+
+    const rootId = 'di-ddl/root'  // main dashboard
+    const midId = 'di-ddl/mid'    // intermediate dashboard
+    const leafId = 'di-ddl/leaf'  // DDL leaf whose table gains a column between v1 and v2
+
+    await publishDdlLeaf(reg, leafId, 'v1', 'CREATE TABLE widgets (id bigint PRIMARY KEY);')
+    await publishDdlLeaf(reg, leafId, 'v2', 'CREATE TABLE widgets (id bigint PRIMARY KEY, label text);')
+
+    await publishDashboard(reg, midId, 'v1', [{ refId: leafId, version: 'v1' }])
+    await publishDashboard(reg, midId, 'v2', [{ refId: leafId, version: 'v2' }])
+
+    await publishDashboard(reg, rootId, 'v1', [{ refId: midId, version: 'v1' }])
+    await publishDashboard(reg, rootId, 'v2', [{ refId: midId, version: 'v2' }])
+
+    const editor = new Editor(rootId, {
+      packageId: rootId,
+      version: 'v2',
+      previousVersionPackageId: rootId,
+      previousVersion: 'v1',
+      buildType: BUILD_TYPE.CHANGELOG,
+      status: VERSION_STATUS.RELEASE,
+    }, {}, reg)
+    const result = await editor.run()
+
+    const ddlIds = result.ddlComparisons.map(packageOf)
+
+    // the DDL leaf's comparison survives two dashboard levels; no intermediate dashboard row appears
+    expect(ddlIds).toContain(leafId)
+    expect(ddlIds).not.toContain(midId)
+  }, 100000)
+
+  // A leaf referenced at CONFLICTING versions through two sub-dashboards: APIHub's
+  // first-occurrence-wins conflict resolution marks the loser `excluded: true` on its reference edge.
+  // The builder must honour that and emit only the winning version, so the same packageId never
+  // appears at two versions in one flattened tree (which would mis-pair prev↔current by refId).
+  test('keeps only the winning version of a package referenced at conflicting versions (drops excluded loser)', async () => {
+    const reg = LocalRegistry.openPackage('exc/root')
+
+    const rootId = 'exc/root'  // main dashboard
+    const subAId = 'exc/subA'  // sub-dashboard declared first → its leaf@v2 wins
+    const subBId = 'exc/subB'  // sub-dashboard declared second → its leaf@v3 is the conflict loser
+    const leafId = 'exc/leaf'  // leaf referenced at v2 (via subA) and v3 (via subB) in the current tree
+
+    await publishLeaf(reg, leafId, 'v1', 'leaf v1')        // previous tree
+    await publishLeaf(reg, leafId, 'v2', 'leaf v2 winner') // current tree, winner
+    await publishLeaf(reg, leafId, 'v3', 'leaf v3 loser')  // current tree, conflict loser
+
+    await publishDashboard(reg, subAId, 'v1', [{ refId: leafId, version: 'v1' }])
+    await publishDashboard(reg, subAId, 'v2', [{ refId: leafId, version: 'v2' }])
+    await publishDashboard(reg, subBId, 'v1', [{ refId: leafId, version: 'v1' }])
+    await publishDashboard(reg, subBId, 'v2', [{ refId: leafId, version: 'v3' }])
+
+    await publishDashboard(reg, rootId, 'v1', [{ refId: subAId, version: 'v1' }, { refId: subBId, version: 'v1' }])
+    await publishDashboard(reg, rootId, 'v2', [{ refId: subAId, version: 'v2' }, { refId: subBId, version: 'v2' }])
+
+    const editor = new Editor(rootId, {
+      packageId: rootId,
+      version: 'v2',
+      previousVersionPackageId: rootId,
+      previousVersion: 'v1',
+      buildType: BUILD_TYPE.CHANGELOG,
+      status: VERSION_STATUS.RELEASE,
+    }, {}, reg)
+    const result = await editor.run()
+
+    const leafComparisons = result.comparisons.filter(comparison => packageOf(comparison) === leafId)
+
+    // exactly one comparison for the leaf, pairing prev v1 → winner v2 (never the excluded v3)
+    expect(leafComparisons).toHaveLength(1)
+    expect(leafComparisons[0].version).toBe('v2')
+    expect(leafComparisons[0].previousVersion).toBe('v1')
+
+    // the excluded (loser) version leaks into no comparison entry
+    expect(result.comparisons.map(comparison => comparison.version)).not.toContain('v3')
+
+    // intermediate dashboards stay dropped; the main comparison is still present
+    const ids = result.comparisons.map(packageOf)
+    expect(ids).toContain(rootId)
+    expect(ids).not.toContain(subAId)
+    expect(ids).not.toContain(subBId)
+  }, 100000)
+
+  // Same conflict, exercised through ddl-comparisons.json: one fix covers both files. The winning
+  // DDL leaf version is compared (v1→v2, adds column `label`); the excluded v3 (adds `note`) is absent.
+  test('keeps only the winning DDL version of a package referenced at conflicting versions', async () => {
+    const reg = LocalRegistry.openPackage('exc-ddl/root')
+
+    const rootId = 'exc-ddl/root'
+    const subAId = 'exc-ddl/subA' // declared first → winner
+    const subBId = 'exc-ddl/subB' // declared second → conflict loser
+    const leafId = 'exc-ddl/leaf'
+
+    await publishDdlLeaf(reg, leafId, 'v1', 'CREATE TABLE widgets (id bigint PRIMARY KEY);')
+    await publishDdlLeaf(reg, leafId, 'v2', 'CREATE TABLE widgets (id bigint PRIMARY KEY, label text);') // winner
+    await publishDdlLeaf(reg, leafId, 'v3', 'CREATE TABLE widgets (id bigint PRIMARY KEY, note text);')  // loser
+
+    await publishDashboard(reg, subAId, 'v1', [{ refId: leafId, version: 'v1' }])
+    await publishDashboard(reg, subAId, 'v2', [{ refId: leafId, version: 'v2' }])
+    await publishDashboard(reg, subBId, 'v1', [{ refId: leafId, version: 'v1' }])
+    await publishDashboard(reg, subBId, 'v2', [{ refId: leafId, version: 'v3' }])
+
+    await publishDashboard(reg, rootId, 'v1', [{ refId: subAId, version: 'v1' }, { refId: subBId, version: 'v1' }])
+    await publishDashboard(reg, rootId, 'v2', [{ refId: subAId, version: 'v2' }, { refId: subBId, version: 'v2' }])
+
+    const editor = new Editor(rootId, {
+      packageId: rootId,
+      version: 'v2',
+      previousVersionPackageId: rootId,
+      previousVersion: 'v1',
+      buildType: BUILD_TYPE.CHANGELOG,
+      status: VERSION_STATUS.RELEASE,
+    }, {}, reg)
+    const result = await editor.run()
+
+    const leafDdlComparisons = result.ddlComparisons.filter(comparison => packageOf(comparison) === leafId)
+
+    // exactly one DDL comparison for the leaf, pairing prev v1 → winner v2 (never the excluded v3)
+    expect(leafDdlComparisons).toHaveLength(1)
+    expect(leafDdlComparisons[0].version).toBe('v2')
+    expect(leafDdlComparisons[0].previousVersion).toBe('v1')
+
+    // the excluded (loser) version leaks into no DDL comparison entry
+    expect(result.ddlComparisons.map(comparison => comparison.version)).not.toContain('v3')
+    expect(result.ddlComparisons.map(packageOf)).not.toContain(subAId)
+    expect(result.ddlComparisons.map(packageOf)).not.toContain(subBId)
+  }, 100000)
+})

--- a/test/helpers/registry/local.ts
+++ b/test/helpers/registry/local.ts
@@ -33,6 +33,7 @@ import {
   isMcpDocument,
   isRestDocument,
   ContractType,
+  KIND_DASHBOARD,
   KIND_PACKAGE,
   Labels,
   MESSAGE_SEVERITY,
@@ -426,32 +427,50 @@ export class LocalRegistry implements IRegistry {
     packageId?: string,
   ): Promise<ResolvedReferences> {
     const references: ReferenceElement[] = []
-    const stack = [{ version, packageId }]
+    // BFS (queue.shift), so "first occurrence" of a packageId is the shallowest, declaration-order
+    // edge — deterministic and intuitive for conflict fixtures.
+    const queue = [{ version, packageId }]
     const packages: ResolvedReferenceMap = {}
+    // first-occurrence-wins: the first version seen for a packageId wins; later edges that reference
+    // the same packageId at a DIFFERENT version are conflict losers, marked excluded (same-version
+    // repeats — diamonds — are not conflicts and stay non-excluded).
+    const winnerVersionByRefId = new Map<string, string>()
 
-    while (stack.length) {
-      const { version, packageId } = stack.pop() ?? {}
+    while (queue.length) {
+      const { version, packageId } = queue.shift() ?? {}
       if (!version || !packageId) {
         continue
       }
       const { config } = await this.getVersion(packageId, version) ?? {}
 
       if (config?.refs?.length) {
+        const parentPackageRef = `${packageId}${REVISION_DELIMITER}${version}`
         for (const ref of config.refs) {
           const packageRef = `${ref.refId}${REVISION_DELIMITER}${ref.version}`
+          // a dashboard is a package that itself declares refs; ordinary (leaf) packages don't
+          const { config: refConfig } = await this.getVersion(ref.refId, ref.version) ?? {}
+          const kind = refConfig?.refs?.length ? KIND_DASHBOARD : KIND_PACKAGE
+          // packages carries every occurrence (losers included); references flags the losers.
           packages[packageRef] = {
             refId: ref.refId,
             version: ref.version,
-            kind: KIND_PACKAGE,
+            kind: kind,
             name: ref.refId,
             status: VERSION_STATUS.DRAFT,
           }
+          const winnerVersion = winnerVersionByRefId.get(ref.refId)
+          if (winnerVersion === undefined) {
+            winnerVersionByRefId.set(ref.refId, ref.version)
+          }
+          const excluded = winnerVersion !== undefined && winnerVersion !== ref.version
           references.push({
             packageRef: packageRef,
+            parentPackageRef: parentPackageRef,
+            ...(excluded ? { excluded: true } : {}),
           })
         }
         for (const ref of config.refs) {
-          stack.push({ packageId: ref.refId, version: ref.version })
+          queue.push({ packageId: ref.refId, version: ref.version })
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes dashboard changelog builds emitting comparison rows the backend does not persist, and mis-pairing package versions when reference conflicts are resolved with `excluded` edges.

Fixes Netcracker/qubership-apihub-backend#462

## Problem

When building a **dashboard changelog**, api-processor flattens the full reference tree and emits entries into `comparisons.json` and `ddl-comparisons.json`. Two bugs caused the build output to diverge from what the backend stores after publication:

1. **Excluded conflict losers** — When the same package is referenced at conflicting versions through different sub-dashboards, backend marks the losing edge with `excluded: true`. The builder previously emitted **all** package occurrences from `ResolvedReferences.packages`, so the same `refId` could appear at two versions in the flattened tree. `compareVersionsReferences` keys pairs by `refId` (last-wins), producing incorrect prev↔current pairings and clearing version-comparison refs after publication.

2. **Intermediate dashboard rows** — Nested dashboards (not the root being built) were included in the comparison output. The comparison for the intermediate dashboard could not be calculated correctly when processing root dashboard, because exlcuded packages versions could be different for root dashboard and intermediate dashboard. Now, the backend only stores a dashboard-pair row when that dashboard is built as the **root**; intermediate dashboard pairs are not persisted and were effectively dropped on publication.


## Solution

**`builder.ts`** — When flattening references from `versionReferencesResolver`, keep only package occurrences that have at least one non-`excluded` reference edge. Forward `kind` onto `BuildConfigRef` so downstream logic can distinguish dashboards from leaf packages.

**`compare.ts`** — Skip `KIND_DASHBOARD` entries in `compareVersionsReferences`. Leaf packages remain separate flat entries in the refs map, so this removes only intermediate dashboard rows. The root dashboard comparison is still emitted separately by `compareVersions`.

**`BuildConfigRef`** — Add optional `kind` (populated by the resolver; absent on locally-resolved `config.refs`).

**Tests** — Extend `LocalRegistry.versionReferencesResolver` to model backend semantics (BFS traversal, `excluded` on conflict losers, dashboard `kind` detection) and add integration tests for nested dashboards, DDL leaves, and conflict exclusion.
