### PR TITLE
fix: preserve colliding operations in changelog

### DIFF
--- a/src/apitypes/rest/rest.changes.ts
+++ b/src/apitypes/rest/rest.changes.ts
@@ -18,6 +18,7 @@ import { RestOperationData } from './rest.types'
 import {
   areDeprecatedOriginsNotEmpty,
   calculateNormalizedRestOperationId,
+  calculateRestOperationId,
   isEmpty,
   isOperationRemove,
   isValidHttpMethod,
@@ -80,6 +81,7 @@ import {
   createOperationChange,
   getOperationTags,
   OperationsMap,
+  resolveOperationPair,
 } from '../../components'
 import { createRestApiCompatibilityScopeFunction } from '../../components/compare/rest.bwc.validation'
 import { calculateApiKindFromLabels, getApiKindProperty } from '../../components/document'
@@ -170,11 +172,17 @@ export const compareDocuments: DocumentsCompare = async (
       const currentBasePath = extractOperationBasePath(methodData?.servers || pathData?.servers || currDocData.servers || [])
       const prevNormalizedOperationId = calculateNormalizedRestOperationId(previousBasePath, path, inferredMethod)
       const currNormalizedOperationId = calculateNormalizedRestOperationId(currentBasePath, path, inferredMethod)
+      // Raw ids disambiguate operations that collide on the normalized id (same-shape parametrized paths)
+      const prevRawOperationId = calculateRestOperationId(previousBasePath, path, inferredMethod)
+      const currRawOperationId = calculateRestOperationId(currentBasePath, path, inferredMethod)
 
-      const {
-        current,
-        previous,
-      } = operationsMap[prevNormalizedOperationId] ?? operationsMap[currNormalizedOperationId] ?? {}
+      const { current, previous } = resolveOperationPair(
+        operationsMap,
+        prevNormalizedOperationId,
+        currNormalizedOperationId,
+        prevRawOperationId,
+        currRawOperationId,
+      )
       if (!current && !previous) {
         const missingOperations = prevNormalizedOperationId === currNormalizedOperationId ? `the ${prevNormalizedOperationId} operation` : `the ${prevNormalizedOperationId} and ${currNormalizedOperationId} operations`
         throw new Error(`Can't find ${missingOperations} from documents pair ${prevDoc?.fileId} and ${currDoc?.fileId}`)

--- a/src/components/compare/compare.utils.ts
+++ b/src/components/compare/compare.utils.ts
@@ -148,11 +148,31 @@ export function removeRedundantPartialPairs<T extends [object | undefined, objec
 
 export function normalizeOperationIds(operations: ResolvedOperation[], apiBuilder: ApiBuilder, groupSlug: string): [(NormalizedOperationId | OperationId)[], Record<NormalizedOperationId | OperationId, ResolvedOperation>] {
   const normalizedOperationIdToOperation: Record<NormalizedOperationId | OperationId, ResolvedOperation> = {}
+
+  // Group by normalized id first: distinct operations can collide on it (e.g. `/{a}/{b}` and `/{c}/{d}` both normalize to `*-*`)
+  const operationsByNormalizedId = new Map<NormalizedOperationId | OperationId, ResolvedOperation[]>()
   operations.forEach(operation => {
     const normalizedOperationId = apiBuilder.createNormalizedOperationId?.(operation) ?? operation.operationId
     // '-' is a slugified slash in the middle of a normalizedOperationId that should also be removed for a proper matching during comparison
-    normalizedOperationIdToOperation[removeGroupPrefixFromOperationId(normalizedOperationId, groupSlug)] = operation
+    const key = removeGroupPrefixFromOperationId(normalizedOperationId, groupSlug)
+
+    const groupedOperations = operationsByNormalizedId.get(key) ?? []
+    groupedOperations.push(operation)
+    operationsByNormalizedId.set(key, groupedOperations)
   })
+
+  for (const [normalizedOperationId, groupedOperations] of operationsByNormalizedId) {
+    if (groupedOperations.length === 1) {
+      const [operation] = groupedOperations
+      normalizedOperationIdToOperation[normalizedOperationId] = operation
+    } else {
+      // Ambiguous normalized id shared by several operations: key by the unique raw operationId so none is dropped
+      for (const operation of groupedOperations) {
+        normalizedOperationIdToOperation[removeGroupPrefixFromOperationId(operation.operationId, groupSlug)] = operation
+      }
+    }
+  }
+
   return [Object.keys(normalizedOperationIdToOperation), normalizedOperationIdToOperation]
 }
 
@@ -181,7 +201,25 @@ export type OperationPair = {
   current?: ResolvedOperation
 }
 
-export type OperationsMap = Record<NormalizedOperationId, OperationPair>
+// Keyed by normalized operation id for unique operations, and by raw operation id for
+// operations that collide on the normalized id (see normalizeOperationIds).
+export type OperationsMap = Record<NormalizedOperationId | OperationId, OperationPair>
+
+// Resolves the operation pair for a path by trying candidate ids in order: normalized ids
+// first (rename-tolerant), then raw ids as a fallback for operations that collide on the
+// normalized id. Returns an empty pair when nothing matches.
+export function resolveOperationPair(
+  operationsMap: OperationsMap,
+  ...candidateIds: (NormalizedOperationId | OperationId)[]
+): OperationPair {
+  for (const id of candidateIds) {
+    const pair = operationsMap[id]
+    if (pair) {
+      return pair
+    }
+  }
+  return {}
+}
 
 /**
  * Pair two `key -> item` maps into `key -> { previous?, current? }`, classifying each key as added

--- a/test/compare.utils.test.ts
+++ b/test/compare.utils.test.ts
@@ -14,7 +14,75 @@
  * limitations under the License.
  */
 
-import { dedupeTuples, removeRedundantPartialPairs } from '../src/components/compare/compare.utils'
+import { createPairOperationsMap, dedupeTuples, normalizeOperationIds, removeRedundantPartialPairs } from '../src/components/compare/compare.utils'
+import { ApiBuilder, ResolvedOperation } from '../src/types'
+
+describe('normalizeOperationIds', () => {
+  const apiBuilder = {
+    createNormalizedOperationId: (operation: ResolvedOperation) => (operation as unknown as { normalizedId: string }).normalizedId,
+  } as unknown as ApiBuilder
+
+  const op = (operationId: string, normalizedId: string): ResolvedOperation =>
+    ({ operationId, normalizedId } as unknown as ResolvedOperation)
+
+  test('should keep distinct operations that share a normalized id by falling back to raw ids', () => {
+    // `/{a}/{b}` and `/{c}/{d}` both normalize to `*-*-get`
+    const op1 = op('a-b-get', '*-*-get')
+    const op2 = op('c-d-get', '*-*-get')
+
+    const [ids, map] = normalizeOperationIds([op1, op2], apiBuilder, '')
+
+    expect([...ids].sort()).toEqual(['a-b-get', 'c-d-get'])
+    expect(map['a-b-get']).toBe(op1)
+    expect(map['c-d-get']).toBe(op2)
+  })
+
+  test('should use the normalized id when it is unique so param-rename matching is preserved', () => {
+    const only = op('a-b-get', 'a-*-get')
+
+    const [ids, map] = normalizeOperationIds([only], apiBuilder, '')
+
+    expect(ids).toEqual(['a-*-get'])
+    expect(map['a-*-get']).toBe(only)
+  })
+})
+
+describe('createPairOperationsMap operation matching', () => {
+  const apiBuilder = {
+    createNormalizedOperationId: (operation: ResolvedOperation) => (operation as unknown as { normalizedId: string }).normalizedId,
+  } as unknown as ApiBuilder
+
+  const op = (operationId: string, normalizedId: string): ResolvedOperation =>
+    ({ operationId, normalizedId } as unknown as ResolvedOperation)
+
+  test('should match a renamed path parameter as one changed operation when the normalized id is unique', () => {
+    // `/users/{id}` -> `/users/{userId}`: same normalized id, so it is matched (not remove + add).
+    const previous = op('users-id-get', 'users-*-get')
+    const current = op('users-userId-get', 'users-*-get')
+
+    const map = createPairOperationsMap('', '', [previous], [current], apiBuilder)
+
+    expect(Object.keys(map)).toEqual(['users-*-get'])
+    expect(map['users-*-get']).toEqual({ previous, current })
+  })
+
+  test('should report a renamed path parameter as remove + add when the normalized id collides (expected)', () => {
+    // Two same-shape paths collide on the normalized id, so they are keyed by raw id. A parameter
+    // rename in one of them changes its raw id, and the collision makes it impossible to tell which
+    // operation it maps to — so it is intentionally reported as remove + add rather than a rename.
+    const renamedPrev = op('a-b-get', '*-*-get')   // /{a}/{b}
+    const renamedCurr = op('a-bb-get', '*-*-get')  // /{a}/{bb} (parameter renamed)
+
+    const stablePrev = op('c-d-get', '*-*-get')    // /{c}/{d}
+    const stableCurr = op('c-d-get', '*-*-get')    // /{c}/{d} (unchanged)
+
+    const map = createPairOperationsMap('', '', [renamedPrev, stablePrev], [renamedCurr, stableCurr], apiBuilder)
+
+    expect(map['c-d-get']).toEqual({ previous: stablePrev, current: stableCurr }) // matched
+    expect(map['a-b-get']).toEqual({ previous: renamedPrev })                     // removed
+    expect(map['a-bb-get']).toEqual({ current: renamedCurr })                     // added
+  })
+})
 
 describe('removeRedundantPartialPairs', () => {
   test('should return empty array when input is empty', () => {

--- a/test/operationId-collisions.test.ts
+++ b/test/operationId-collisions.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  buildChangelogPackage,
   changesSummaryMatcher,
   Editor,
   LocalRegistry,
@@ -24,7 +25,14 @@ import {
 } from './helpers'
 import { describe, expect, test } from '@jest/globals'
 import { calculateRestOperationId, calculateNormalizedRestOperationId, _calculateRestOperationIdV1 } from '../src/utils/operations.utils'
-import { BUILD_TYPE, MESSAGE_SEVERITY, VERSION_STATUS } from '../src'
+import { BUILD_TYPE, BuildResult, MESSAGE_SEVERITY, VERSION_STATUS } from '../src'
+
+function changedOperationIds(result: BuildResult): string[] {
+  return (result.comparisons ?? [])
+    .flatMap((comparison) => (comparison as { data?: { operationId?: string }[] }).data ?? [])
+    .map((change) => change.operationId ?? '')
+    .sort()
+}
 
 describe('Operation ID collisions', () => {
   describe('operationID and normalizedOperationId calculation', () => {
@@ -318,6 +326,61 @@ describe('Operation ID collisions', () => {
           type: 'annotation',
         }),
       ]))
+    })
+  })
+
+  // Changelog operation matching by normalized operation id.
+  //
+  // Operations are paired across versions by their normalized id (path params -> `*`). A unique
+  // normalized id lets a path-param rename match as one changed operation. Distinct same-shape
+  // fully-parametrized paths collide on that id (e.g. `/{a}/{b}/{c}` -> `*-*-*-get`); the changelog
+  // used to overwrite one with the other, dropping / duplicating it in the comparison.
+  describe('Changelog operation matching on normalized id', () => {
+
+    test('should match a renamed path parameter as one changed operation, leaving sibling operations untouched', async () => {
+      // Two operations with unique normalized ids: `/users/{id}` is renamed to `/users/{userId}`
+      // (same `users-*-get`), while `/orders/{ref}` is unchanged. The renamed operation must be
+      // matched to its counterpart and reported as a single change (not remove + add), and the
+      // untouched sibling must not appear as a change at all.
+      const result = await buildChangelogPackage('operationId-collisions/rename')
+
+      expect(changedOperationIds(result)).toEqual(['users-_userId_-get'])
+    })
+
+    test('should preserve both operations when normalized operation ids collide', async () => {
+      // before.yaml/after.yaml differ only by the server url, so both operations change.
+      const result = await buildChangelogPackage('operationId-collisions/collision')
+
+      expect(changedOperationIds(result)).toEqual([
+        '_name_-_profile_-_path_-get',
+        '_name_-_profiles_-_label_-get',
+      ].sort())
+    })
+
+    test('should resolve colliding operations that share an operation-level base path', async () => {
+      // Both operations carry the same operation-level base path (/api/v1). The raw-id fallback
+      // must recompute the id with that base path — otherwise the build fails with
+      // "Can't find operation".
+      const result = await buildChangelogPackage('operationId-collisions/operation-level-servers')
+
+      expect(changedOperationIds(result)).toEqual([
+        'api-v1-_a_-_b_-_c_-get',
+        'api-v1-_x_-_y_-_z_-get',
+      ].sort())
+    })
+
+    test('should resolve colliding and uniquely-normalized operations together in one document', async () => {
+      // `/{a}/{b}` and `/{c}/{d}` collide on `*-*-get` (keyed by raw id), while `/orders/{id}` has a
+      // unique normalized id `orders-*-get` (keyed by normalized id). A server url change touches all
+      // three; each must be reported exactly once, proving the raw-id fallback and normalized-id
+      // matching coexist without dropping or duplicating operations.
+      const result = await buildChangelogPackage('operationId-collisions/mixed')
+
+      expect(changedOperationIds(result)).toEqual([
+        '_a_-_b_-get',
+        '_c_-_d_-get',
+        'orders-_id_-get',
+      ].sort())
     })
   })
 })

--- a/test/projects/operationId-collisions/collision/after.yaml
+++ b/test/projects/operationId-collisions/collision/after.yaml
@@ -1,0 +1,18 @@
+# Same as before.yaml, only the server url changed (a.local → b.local).
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+servers:
+  - url: http://b.local
+paths:
+  /{name}/{profile}/{path}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /{name}/{profiles}/{label}:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/collision/before.yaml
+++ b/test/projects/operationId-collisions/collision/before.yaml
@@ -1,0 +1,19 @@
+# Two distinct fully-parametrized paths of the same shape → same normalized id (`*-*-*-get`).
+# Only the server url changes in after.yaml, which is a change for BOTH operations.
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+servers:
+  - url: http://a.local
+paths:
+  /{name}/{profile}/{path}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /{name}/{profiles}/{label}:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/mixed/after.yaml
+++ b/test/projects/operationId-collisions/mixed/after.yaml
@@ -1,0 +1,24 @@
+# Same as before.yaml, only the server url changed (a.local -> b.local), which is a change for all
+# three operations.
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+servers:
+  - url: http://b.local
+paths:
+  /{a}/{b}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /{c}/{d}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /orders/{id}:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/mixed/before.yaml
+++ b/test/projects/operationId-collisions/mixed/before.yaml
@@ -1,0 +1,27 @@
+# A document mixing both matching cases in one comparison:
+#   - `/{a}/{b}` and `/{c}/{d}` collide on the normalized id `*-*-get` -> keyed by their raw ids.
+#   - `/orders/{id}` has a unique normalized id `orders-*-get` -> keyed by the normalized id.
+# Only the server url changes in after.yaml, so all three operations change and each must be
+# reported exactly once (nothing dropped or duplicated).
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+servers:
+  - url: http://a.local
+paths:
+  /{a}/{b}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /{c}/{d}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /orders/{id}:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/operation-level-servers/after.yaml
+++ b/test/projects/operationId-collisions/operation-level-servers/after.yaml
@@ -1,0 +1,22 @@
+# Same as before.yaml, only the root server url changed (root.local → root2.local).
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+servers:
+  - url: http://root2.local
+paths:
+  /{a}/{b}/{c}:
+    get:
+      servers:
+        - url: http://svc.local/api/v1
+      responses:
+        '200':
+          description: OK
+  /{x}/{y}/{z}:
+    get:
+      servers:
+        - url: http://svc.local/api/v1
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/operation-level-servers/before.yaml
+++ b/test/projects/operationId-collisions/operation-level-servers/before.yaml
@@ -1,0 +1,24 @@
+# Same-shape collision, but both operations carry the same operation-level base path
+# (/api/v1). The raw-id fallback must recompute the id with that base path.
+# Only the root server url changes in after.yaml.
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+servers:
+  - url: http://root.local
+paths:
+  /{a}/{b}/{c}:
+    get:
+      servers:
+        - url: http://svc.local/api/v1
+      responses:
+        '200':
+          description: OK
+  /{x}/{y}/{z}:
+    get:
+      servers:
+        - url: http://svc.local/api/v1
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/rename/after.yaml
+++ b/test/projects/operationId-collisions/rename/after.yaml
@@ -1,0 +1,18 @@
+# `/users/{id}` -> `/users/{userId}`: path parameter renamed and the response description changed,
+# so there is a genuine change to attribute to the single matched operation. `/orders/{ref}` is left
+# exactly as before.yaml.
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      responses:
+        '200':
+          description: Updated
+  /orders/{ref}:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/projects/operationId-collisions/rename/before.yaml
+++ b/test/projects/operationId-collisions/rename/before.yaml
@@ -1,0 +1,19 @@
+# Two operations with unique normalized ids. In after.yaml the first one has its path parameter
+# renamed (`/users/{id}` -> `/users/{userId}`, same normalized id `users-*-get`) and must be matched
+# as ONE changed operation (not remove + add). The second one (`/orders/{ref}`) is unchanged and must
+# not surface as a change.
+openapi: 3.0.0
+info:
+  title: t
+  version: 1.0.0
+paths:
+  /users/{id}:
+    get:
+      responses:
+        '200':
+          description: OK
+  /orders/{ref}:
+    get:
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
### Root cause
Distinct but same-shape fully-parametrized paths normalize to the **same** operation id
(e.g. `/{a}/{b}` and `/{c}/{d}` both → `*-*-get`). The changelog keyed operations by that normalized id, so one operation overwrote the other in the operations map — its changes became invisible or got misattributed.

## What changed

- **`normalizeOperationIds` (`compare.utils.ts`)** — operations are now grouped by their normalized id first:
  - **unique** normalized id → kept as the key (rename-tolerant: a renamed path parameter still matches its counterpart);
  - **colliding** normalized id → each operation is keyed by its unique **raw** `operationId`, so none is dropped.
- **New `resolveOperationPair` helper** — variadic lookup that tries candidate ids in order (normalized first, then raw), returning an empty pair when nothing matches. Replaces the previous inline `?? ... ??` fallback chain.
- **`rest.changes.ts` (`compareDocuments`)** — computes the raw operation ids (`calculateRestOperationId`) and resolves the pair through `resolveOperationPair`. This is required by the raw-id keying above; without it the normalized lookup misses on collisions and the build fails with `Can't find operation`.
- **`OperationsMap` type** widened to `Record<NormalizedOperationId | OperationId, OperationPair>`.

## Behaviour notes

- A path-parameter rename with a **unique** normalized id is matched as **one changed operation** (not remove + add).
- A rename **inside a collision group** is inherently ambiguous, so it is reported as remove + add — the deterministic, safe choice.
