### PR TITLE
fix: exclude revision from comparison internal document id

### DIFF
--- a/src/components/compare/compare.utils.ts
+++ b/src/components/compare/compare.utils.ts
@@ -38,6 +38,7 @@ import {
   calculateChangeSummary,
   calculateImpactedSummary,
   difference,
+  getSplittedVersionKey,
   intersection,
   removeFirstSlash,
   serializeDocument,
@@ -345,7 +346,9 @@ export const createComparisonInternalDocumentId = (
   currentPackageId: string,
   currSlug: string | undefined,
 ): string => {
-  return createComparisonFileId([prevSlug, previousVersion, previousPackageId || currentPackageId], [currSlug, currentVersion, currentPackageId])
+  const [previousVersionKey] = getSplittedVersionKey(previousVersion)
+  const [currentVersionKey] = getSplittedVersionKey(currentVersion)
+  return createComparisonFileId([prevSlug, previousVersionKey, previousPackageId || currentPackageId], [currSlug, currentVersionKey, currentPackageId])
 }
 
 export const removeGroupPrefixFromOperationId = (operationId: string, groupPrefix: string): string => {

--- a/test/comparison-internal-documents.test.ts
+++ b/test/comparison-internal-documents.test.ts
@@ -59,6 +59,16 @@ describe('Comparison Internal Documents tests', () => {
 
       expect(beforeInternalDocumentId).not.toEqual(afterInternalDocumentId)
     })
+
+    it('should ignore the revision so the id is stable regardless of when it is known', () => {
+      const withoutRevision = createComparisonInternalDocumentId('release1', 'pkgA', 'slugA', 'release2', 'pkgB', 'slugB')
+      const withCurrentRevision = createComparisonInternalDocumentId('release1', 'pkgA', 'slugA', 'release2@4', 'pkgB', 'slugB')
+      const withBothRevisions = createComparisonInternalDocumentId('release1@1', 'pkgA', 'slugA', 'release2@4', 'pkgB', 'slugB')
+
+      expect(withCurrentRevision).toEqual(withoutRevision)
+      expect(withBothRevisions).toEqual(withoutRevision)
+      expect(withoutRevision).not.toContain('@')
+    })
   })
 
   describe('OAS tests', () => {


### PR DESCRIPTION
## Problem

The **comparison internal document id** embeds the version's revision, so the same
comparison produces a **different id depending on when it is built**.

A version's revision is unknown at publish time and is only assigned by the backend
afterwards. As a result:

- at **publish** the id looks like `admin_api_internal_release1@1_TEST1.PKG2_release2_TEST1.PKG2`
  (current version has no revision yet);
- after a **migration** build the same comparison is recalculated to
  `..._release2@4_TEST1.PKG2` (the revision `@4` is now known).

The mismatch surfaces as suspicious / duplicated builds for the package.

## Fix

Strip the revision from both versions when building the id, in the single shared
`createComparisonInternalDocumentId` (`src/components/compare/compare.utils.ts`).
`prevSlug + prevVersion + prevPackageId` and `currSlug + currVersion + currPackageId`
are enough to keep ids unique, and revision is never actually part of the identity —
the version just arrives in the `version@revision` form, so it is trimmed via
`getSplittedVersionKey`.

Why this is the right place:

- **One central point** fixes REST, GraphQL and AsyncAPI at once (they all call this helper).
- **Idempotent no-op for DDL**, which already trims the revision before calling — this only
  brings the other API types in line with that existing behavior.
- The operation-change reference id and the comparison-document id come from the same value,
  so they stay consistent.
- `rawDocumentResolver` still receives the raw `version@revision` (it needs the real revision
  to fetch the document) — only the id is trimmed.

The outer `comparisonFileId` is **not** affected: it is built from the build config
(`config.version`, without a revision) and is already stable across publish / migration.

## Notes

The comparison document id is only an internal cross-reference between `operationChanges`
and comparison documents within a single build result; it is not part of any API hash.
