### PR TITLE
fix: build a changelog for versions published from a GraphQL introspection

### DIFF
--- a/src/apitypes/graphql/graphql.changes.ts
+++ b/src/apitypes/graphql/graphql.changes.ts
@@ -15,7 +15,7 @@
  */
 
 import { calculateGraphqlOperationId, isEmpty, takeIf } from '../../utils'
-import { parseGraphQLSource } from '../../utils/graphql-transformer'
+import { parseGraphQLDocument } from './graphql.document'
 import {
   aggregateDiffsWithRollup,
   apiDiff,
@@ -69,9 +69,9 @@ export const compareDocuments: DocumentsCompare = async (
   const comparisonInternalDocumentId = createComparisonInternalDocumentId(previousVersion, previousPackageId, prevDoc?.slug, currentVersion, currentPackageId, currDoc?.slug)
   const prevFile = prevDoc && await rawDocumentResolver(previousVersion, previousPackageId, prevDoc.slug)
   const currFile = currDoc && await rawDocumentResolver(currentVersion, currentPackageId, currDoc.slug)
-  // The raw document is SDL whatever the version was published from, so parse it as a schema.
-  let prevDocData = prevFile && parseGraphQLSource(await prevFile.text())
-  let currDocData = currFile && parseGraphQLSource(await currFile.text())
+
+  let prevDocData = prevFile && prevDoc && parseGraphQLDocument(await prevFile.text(), prevDoc.type, prevDoc.format)
+  let currDocData = currFile && currDoc && parseGraphQLDocument(await currFile.text(), currDoc.type, currDoc.format)
 
   if (!prevDocData && currDocData) {
     prevDocData = getCopyWithEmptyOperations(currDocData)

--- a/src/apitypes/graphql/graphql.changes.ts
+++ b/src/apitypes/graphql/graphql.changes.ts
@@ -15,6 +15,7 @@
  */
 
 import { calculateGraphqlOperationId, isEmpty, takeIf } from '../../utils'
+import { parseGraphQLSource } from '../../utils/graphql-transformer'
 import {
   aggregateDiffsWithRollup,
   apiDiff,
@@ -29,14 +30,11 @@ import {
   ORIGINS_SYMBOL,
 } from '../../consts'
 import { GraphApiOperation, GraphApiSchema } from '@netcracker/qubership-apihub-graphapi'
-import { buildSchema } from 'graphql/utilities'
-import { buildGraphQLDocument } from './graphql.document'
 import {
   CompareOperationsPairContext,
   ComparisonDocument,
   DocumentsCompare,
   DocumentsCompareData,
-  FILE_KIND,
   OperationChanges,
   ResolvedVersionDocument,
   WithAggregatedDiffs,
@@ -71,21 +69,9 @@ export const compareDocuments: DocumentsCompare = async (
   const comparisonInternalDocumentId = createComparisonInternalDocumentId(previousVersion, previousPackageId, prevDoc?.slug, currentVersion, currentPackageId, currDoc?.slug)
   const prevFile = prevDoc && await rawDocumentResolver(previousVersion, previousPackageId, prevDoc.slug)
   const currFile = currDoc && await rawDocumentResolver(currentVersion, currentPackageId, currDoc.slug)
-  const prevDocSchema = prevFile && buildSchema(await prevFile.text(), { noLocation: true })
-  const currDocSchema = currFile && buildSchema(await currFile.text(), { noLocation: true })
-
-  let prevDocData = prevDocSchema && (await buildGraphQLDocument({
-    ...prevDoc,
-    source: prevFile,
-    kind: FILE_KIND.TEXT,
-    data: prevDocSchema,
-  }, prevDoc)).data
-  let currDocData = currDocSchema && (await buildGraphQLDocument({
-    ...currDoc,
-    source: currFile,
-    kind: FILE_KIND.TEXT,
-    data: currDocSchema,
-  }, currDoc)).data
+  // The raw document is SDL whatever the version was published from, so parse it as a schema.
+  let prevDocData = prevFile && parseGraphQLSource(await prevFile.text())
+  let currDocData = currFile && parseGraphQLSource(await currFile.text())
 
   if (!prevDocData && currDocData) {
     prevDocData = getCopyWithEmptyOperations(currDocData)

--- a/src/apitypes/graphql/graphql.document.ts
+++ b/src/apitypes/graphql/graphql.document.ts
@@ -20,35 +20,66 @@ import {
   GraphApiSchema,
   printGraphApi,
 } from '@netcracker/qubership-apihub-graphapi'
-import type { GraphQLSchema, IntrospectionQuery } from 'graphql'
+import { buildSchema, type GraphQLSchema, type IntrospectionQuery } from 'graphql'
+import { loadYaml } from '@netcracker/qubership-apihub-api-unifier'
 
-import { BuildConfigFile, DocumentDumper, ExportDocument, ExportFormat, TextFile, VersionDocument } from '../../types'
-import { GRAPHQL_DOCUMENT_TYPE } from './graphql.consts'
-import { createVersionInternalDocument, getDocumentTitle } from '../../utils'
-import { GRAPHQL_API_TYPE } from '../../consts'
+import { BuildConfigFile, DocumentDumper, FileFormat, TextFile, VersionDocument } from '../../types'
+import { GRAPHQL_DOCUMENT_TYPE, GRAPHQL_FILE_FORMAT } from './graphql.consts'
+import { FILE_FORMAT } from '../../consts'
+import { createVersionInternalDocument, isObject } from '../../utils'
+
+function toGraphApiSchema(data: unknown, type: string): GraphApiSchema {
+  switch (type) {
+    case GRAPHQL_DOCUMENT_TYPE.INTROSPECTION: {
+      if (!isObject(data)) {
+        throw new Error('A GraphQL introspection document must be an object')
+      }
+      const introspection = ('__schema' in data ? data : data.data) as IntrospectionQuery
+      return buildFromIntrospection(introspection)
+    }
+    case GRAPHQL_DOCUMENT_TYPE.SCHEMA:
+      return buildFromSchema(data as GraphQLSchema)
+    case GRAPHQL_DOCUMENT_TYPE.GRAPHAPI:
+      return data as GraphApiSchema
+    default:
+      throw new Error(`Unsupported type "${type}" for a GraphQL document`)
+  }
+}
+
+/** Read a stored document back into a GraphAPI schema using the type and format persisted alongside it. */
+export function parseGraphQLDocument(source: string, type: string, format: FileFormat): GraphApiSchema {
+  return toGraphApiSchema(parseDocumentSource(source, format), type)
+}
+
+function parseDocumentSource(source: string, format: FileFormat): unknown {
+  switch (format) {
+    case GRAPHQL_FILE_FORMAT.GRAPHQL:
+    case GRAPHQL_FILE_FORMAT.GQL:
+      return buildSchema(source, { noLocation: true })
+    case GRAPHQL_FILE_FORMAT.JSON:
+      return JSON.parse(source)
+    case GRAPHQL_FILE_FORMAT.YAML:
+    case FILE_FORMAT.YML:
+      return loadYaml(source)
+    default:
+      throw new Error(`Unsupported format "${format}" for a GraphQL document`)
+  }
+}
 
 export const buildGraphQLDocument = async (parsedFile: TextFile, file: BuildConfigFile): Promise<VersionDocument<GraphApiSchema>> => {
-  let graphapi: GraphApiSchema
-  if (parsedFile.type === GRAPHQL_DOCUMENT_TYPE.INTROSPECTION) {
-    const introspection = (parsedFile?.data && '__schema' in parsedFile.data ? parsedFile?.data : parsedFile.data?.data) as IntrospectionQuery
-    graphapi = buildFromIntrospection(introspection)
-  } else if (parsedFile.type === GRAPHQL_DOCUMENT_TYPE.SCHEMA) {
-    graphapi = buildFromSchema(parsedFile.data as GraphQLSchema)
-  } else {
-    graphapi = parsedFile.data as GraphApiSchema
-  }
+  const graphapi = toGraphApiSchema(parsedFile.data, parsedFile.type)
 
   const { fileId, slug = '', publish = true, apiKind, ...metadata } = file
-  const { format, type, source } = parsedFile
+  const { source } = parsedFile
   return {
     fileId,
-    type,
-    format,
+    type: GRAPHQL_DOCUMENT_TYPE.SCHEMA,
+    format: GRAPHQL_FILE_FORMAT.GRAPHQL,
     data: graphapi,
     publish,
     apiKind,
     slug, // unique slug should be already generated
-    filename: `${slug}.graphql`,
+    filename: `${slug}.${GRAPHQL_FILE_FORMAT.GRAPHQL}`,
     title: fileId.split('/').pop()!.replace(/\.[^/.]+$/, ''),
     dependencies: [],
     description: graphapi.description || '',

--- a/test/graphql-changes.test.ts
+++ b/test/graphql-changes.test.ts
@@ -18,10 +18,17 @@ import {
   buildChangelogPackage,
   buildGqlChangelogPackage,
   changesSummaryMatcher,
+  LocalRegistry,
   numberOfImpactedOperationsMatcher,
   operationChangesMatcher,
 } from './helpers'
-import { BREAKING_CHANGE_TYPE, GRAPHQL_API_TYPE, NON_BREAKING_CHANGE_TYPE } from '../src'
+import {
+  BREAKING_CHANGE_TYPE,
+  GRAPHQL_API_TYPE,
+  GRAPHQL_DOCUMENT_TYPE,
+  GRAPHQL_FILE_FORMAT,
+  NON_BREAKING_CHANGE_TYPE,
+} from '../src'
 
 describe('Graphql changes test', () => {
   describe('Added/removed/changed operations handling', () => {
@@ -44,8 +51,8 @@ describe('Graphql changes test', () => {
     })
   })
 
-  // A `.json` introspection source keeps `type: introspection` in the documents, but the changelog
-  // re-reads them as SDL, so the previous document has to be processed as a schema, not introspection.
+  // Both versions are published by the current builder, so their documents describe the artifact and are
+  // read back as SDL. The introspection and graphapi read paths are covered in `graphql-transformer.test.ts`.
   test('should parse the previous document published from introspection to build a diff', async () => {
     const result = await buildChangelogPackage(
       'graphql-changes/introspection',
@@ -57,6 +64,27 @@ describe('Graphql changes test', () => {
     // after.json adds Query.author to before.json
     expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
     expect(result).toEqual(numberOfImpactedOperationsMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+  })
+
+  test.each([
+    ['an introspection response', 'graphql-changes/introspection', 'before.json'],
+    ['a GraphAPI document', 'graphql-changes/graphapi', 'source.json'],
+    ['SDL', 'graphql-changes/add-operation', 'before.gql'],
+  ])('should describe a document published from %s as the SDL it is stored as', async (_, project, fileId) => {
+    const registry = new LocalRegistry(project)
+
+    const result = await registry.publish(project, {
+      packageId: 'graphql-artifact-metadata',
+      version: 'v1',
+      files: [{ fileId: fileId, publish: true }],
+    })
+
+    const [document] = Array.from(result.documents.values())
+    expect(document).toEqual(expect.objectContaining({
+      type: GRAPHQL_DOCUMENT_TYPE.SCHEMA,
+      format: GRAPHQL_FILE_FORMAT.GRAPHQL,
+      filename: `${document.slug}.${GRAPHQL_FILE_FORMAT.GRAPHQL}`,
+    }))
   })
 
   test('Operation changes fields are correct', async () => {

--- a/test/graphql-changes.test.ts
+++ b/test/graphql-changes.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  buildChangelogPackage,
   buildGqlChangelogPackage,
   changesSummaryMatcher,
   numberOfImpactedOperationsMatcher,
@@ -41,6 +42,21 @@ describe('Graphql changes test', () => {
       expect(result).toEqual(changesSummaryMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
       expect(result).toEqual(numberOfImpactedOperationsMatcher({ [BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
     })
+  })
+
+  // A `.json` introspection source keeps `type: introspection` in the documents, but the changelog
+  // re-reads them as SDL, so the previous document has to be processed as a schema, not introspection.
+  test('should parse the previous document published from introspection to build a diff', async () => {
+    const result = await buildChangelogPackage(
+      'graphql-changes/introspection',
+      [{ fileId: 'before.json' }],
+      [{ fileId: 'after.json' }],
+    )
+
+    expect(result.notifications).toEqual([])
+    // after.json adds Query.author to before.json
+    expect(result).toEqual(changesSummaryMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
+    expect(result).toEqual(numberOfImpactedOperationsMatcher({ [NON_BREAKING_CHANGE_TYPE]: 1 }, GRAPHQL_API_TYPE))
   })
 
   test('Operation changes fields are correct', async () => {

--- a/test/graphql-transformer.test.ts
+++ b/test/graphql-transformer.test.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { cropRawGraphQlDocumentToRawSingleOperationGraphQlDocument } from '../src'
+import { cropRawGraphQlDocumentToRawSingleOperationGraphQlDocument, GRAPHQL_DOCUMENT_TYPE, GRAPHQL_FILE_FORMAT } from '../src'
+import type { FileFormat } from '../src'
 import { buildSchema } from 'graphql'
 import { loadFileAsString } from './helpers'
+import { parseGraphQLDocument } from '../src/apitypes/graphql/graphql.document'
 
 describe('Crop raw graphql document to raw single operation document tests', () => {
   let graphql: string
@@ -143,3 +145,39 @@ describe('Crop raw graphql document to raw single operation document tests', () 
     expect(Object.keys(queryFields)).toEqual(['hello'])
   })
 })
+
+/**
+ * A published GraphQL document is stored as SDL today, so the introspection and graphapi branches are not
+ * reachable through a publish. They exist for the day the real source document is persisted instead, and
+ * these cases keep them honest.
+ */
+describe('Parse a stored GraphQL document by its persisted type and format', () => {
+  const SDL = 'type Query { book: String }'
+  const GRAPHAPI = JSON.stringify({ graphapi: '0.0.1', queries: { book: { output: { typeDef: { type: { kind: 'string' } } } } } })
+
+  test.each([
+    ['SDL', SDL, GRAPHQL_DOCUMENT_TYPE.SCHEMA, GRAPHQL_FILE_FORMAT.GRAPHQL],
+    ['SDL under the gql extension', SDL, GRAPHQL_DOCUMENT_TYPE.SCHEMA, GRAPHQL_FILE_FORMAT.GQL],
+    ['a GraphAPI document', GRAPHAPI, GRAPHQL_DOCUMENT_TYPE.GRAPHAPI, GRAPHQL_FILE_FORMAT.JSON],
+  ])('should read %s', (_, source, type, format) => {
+    const schema = parseGraphQLDocument(source, type, format)
+
+    expect(Object.keys(schema.queries ?? {})).toEqual(['book'])
+  })
+
+  test('should read an introspection response', async () => {
+    const introspection = await loadFileAsString('test/projects/', 'graphql-changes/introspection', 'before.json') as string
+
+    const schema = parseGraphQLDocument(introspection, GRAPHQL_DOCUMENT_TYPE.INTROSPECTION, GRAPHQL_FILE_FORMAT.JSON)
+
+    expect(Object.keys(schema.queries ?? {})).toEqual(['book'])
+  })
+
+  test.each([
+    ['a format it cannot read', SDL, GRAPHQL_DOCUMENT_TYPE.SCHEMA, 'md', 'Unsupported format "md" for a GraphQL document'],
+    ['an introspection document that is not an object', '42', GRAPHQL_DOCUMENT_TYPE.INTROSPECTION, GRAPHQL_FILE_FORMAT.JSON, 'A GraphQL introspection document must be an object'],
+  ])('should reject %s', (_, source, type, format, message) => {
+    expect(() => parseGraphQLDocument(source, type, format as FileFormat)).toThrow(message)
+  })
+})
+

--- a/test/helpers/registry/local.ts
+++ b/test/helpers/registry/local.ts
@@ -698,8 +698,7 @@ export class LocalRegistry implements IRegistry {
 
       if (data) {
         const source = data
-        // `format` is the source format, but a graphql document is always written as SDL.
-        const isJson = document.format === FILE_FORMAT.JSON && !isGraphqlDocument(document)
+        const isJson = document.format === FILE_FORMAT.JSON
         versionCache.documents.set(document.slug, {
           ...document,
           data: isJson ? JSON.parse(data) : '',

--- a/test/helpers/registry/local.ts
+++ b/test/helpers/registry/local.ts
@@ -698,7 +698,8 @@ export class LocalRegistry implements IRegistry {
 
       if (data) {
         const source = data
-        const isJson = document.format === FILE_FORMAT.JSON
+        // `format` is the source format, but a graphql document is always written as SDL.
+        const isJson = document.format === FILE_FORMAT.JSON && !isGraphqlDocument(document)
         versionCache.documents.set(document.slug, {
           ...document,
           data: isJson ? JSON.parse(data) : '',

--- a/test/projects/graphql-changes/graphapi/source.json
+++ b/test/projects/graphql-changes/graphapi/source.json
@@ -1,0 +1,14 @@
+{
+  "graphapi": "0.0.1",
+  "queries": {
+    "book": {
+      "output": {
+        "typeDef": {
+          "type": {
+            "kind": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/projects/graphql-changes/introspection/after.json
+++ b/test/projects/graphql-changes/introspection/after.json
@@ -1,0 +1,20 @@
+{
+    "errors": [],
+    "data": {
+        "__schema": {
+            "queryType": { "name": "Query" },
+            "types": [
+                {
+                    "kind": "OBJECT",
+                    "name": "Query",
+                    "fields": [
+                        { "name": "book", "args": [], "type": { "kind": "SCALAR", "name": "String" } },
+                        { "name": "author", "args": [], "type": { "kind": "SCALAR", "name": "String" } }
+                    ]
+                }
+            ]
+        }
+    },
+    "extensions": {},
+    "dataPresent": true
+}

--- a/test/projects/graphql-changes/introspection/before.json
+++ b/test/projects/graphql-changes/introspection/before.json
@@ -1,0 +1,19 @@
+{
+    "errors": [],
+    "data": {
+        "__schema": {
+            "queryType": { "name": "Query" },
+            "types": [
+                {
+                    "kind": "OBJECT",
+                    "name": "Query",
+                    "fields": [
+                        { "name": "book", "args": [], "type": { "kind": "SCALAR", "name": "String" } }
+                    ]
+                }
+            ]
+        }
+    },
+    "extensions": {},
+    "dataPresent": true
+}


### PR DESCRIPTION
## Why

Publish a GraphQL introspection response as a release, then publish a second release with the first one as
its previous version, and the build crashes:

```text
TypeError: Cannot destructure property '__schema' of 'undefined' as it is undefined.
    at buildFromIntrospection (@netcracker/qubership-apihub-graphapi)
    at buildGraphQLDocument (src/apitypes/graphql/graphql.document.ts:34)
    at compareDocuments (src/apitypes/graphql/graphql.changes.ts)
```

The first publication succeeds. The failure happens on the second one, while comparing the two versions —
which is the agent-wizard snapshot flow reported in the issue.

A `graphapi`-sourced document hit the same mismatch without crashing: it fell into the `else` branch, where a
`GraphQLSchema` was handed to code expecting a `GraphApiSchema`, and the comparison ran over the wrong
structure. Only SDL sources were accidentally correct.

## Root cause

A GraphQL document is **always stored as printed SDL** — `dumpGraphQLDocument` runs `printGraphApi` and
writes `<slug>.graphql` — whatever the source was. But `documents.json` kept the metadata of the **source**:
for an introspection response that is `type: introspection`, `format: json`.

`compareDocuments` rebuilt the document through `buildGraphQLDocument`, spreading the stored document to fill
in the remaining fields. The spread carried the stale `type`, so the introspection branch looked for
`__schema` inside a `GraphQLSchema`. `'__schema' in schema` is `false` and `schema.data` is `undefined`, hence
the crash inside graphapi.

## What changed

**The document metadata now describes the artifact, not the source.** `buildGraphQLDocument` records
`type: graphql-schema`, `format: graphql` and derives the filename extension from the same constant. SDL is
what actually gets stored, so this is simply the truth about the file on disk — and it keeps working if the
real source document is persisted instead one day.

**Reading a stored document goes by those persisted fields.** `graphql.changes.ts` parses the raw file
directly instead of rebuilding a document to get at its model:

```ts
let prevDocData = prevFile && prevDoc && parseGraphQLDocument(await prevFile.text(), prevDoc.type, prevDoc.format)
let currDocData = currFile && currDoc && parseGraphQLDocument(await currFile.text(), currDoc.type, currDoc.format)
```

`parseGraphQLDocument` pairs `parseDocumentSource(source, format)` — SDL, JSON or YAML — with
`toGraphApiSchema(data, type)`, which is the branching `buildGraphQLDocument` already had, now extracted and
shared by the write and read paths. Both `default` branches **throw** rather than cast: the silent cast is
what produced a meaningless changelog instead of an error.

This drops the fake `TextFile` the old code assembled (whose `format` field also lied), a duplicated
`buildSchema` call and four imports.
